### PR TITLE
Add multi-calculator support with 401k

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
-# Professional 30-Year REIT Analysis (React + TypeScript)
+# Investment Analyzer: Multi-Calculator Toolkit (React + TypeScript)
 
-A professional, interactive tool for analyzing real estate investment trusts (REITs) over a 30-year period. This application is a modern, maintainable replacement for a previous HTML version, built with a focus on a clean UI and robust calculation logic.
+A professional, interactive platform for modeling a variety of long-term investment strategies. It includes calculators for REIT portfolios, Roth IRA accounts, and detailed 401k growth projections, all wrapped in a clean and modern interface.
 
 ## Features
-- Comprehensive 30-year financial analysis with monthly granularity.
-- Accurate cash-out refinancing model including closing costs and seasoning periods.
-- Supports 1031 exchanges for tax-deferred property acquisition.
-- Detailed rental yield calculation with both itemized expense breakdown and net yield options.
-- Year-by-year breakdown of portfolio performance, cash flows, and debt.
-- Interactive charts for portfolio composition, annual cash flow, and overall portfolio value, net equity, and debt over time.
-- Modern and responsive user interface built with React and Material-UI.
+- Comprehensive 30-year projections with monthly granularity.
+- Real estate modeling with cash-out refinancing and 1031 exchanges.
+- Roth IRA and 401k growth calculators with employer matching options.
+- Year-by-year breakdown of portfolio performance and cash flows.
+- Interactive charts for asset allocation, contributions, and equity growth.
+- Modern and responsive user interface built with React and Tailwind CSS.
 
 ## Technology Stack
 - **Frontend:** React, TypeScript, Material-UI (MUI)

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>REIT Fund Model - Advanced Portfolio Calculator</title>
-    <meta name="description" content="Professional REIT investment calculator with comprehensive 30-year analysis, cash flow projections, and interactive visualizations." />
+    <title>Investment Analyzer - Multi-Calculator Portfolio Tool</title>
+    <meta name="description" content="Versatile investment calculator offering REIT, Roth IRA, and 401k projections with interactive charts and detailed analysis." />
     
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,17 +2,19 @@ import React, { useState } from 'react';
 import { Building2, Calculator, ChartBar, TrendingUp, ChevronDown, ChevronUp, Info, Zap, Activity } from 'lucide-react';
 import CalculatorForm from './components/CalculatorForm';
 import RothIRAForm from './components/RothIRAForm';
+import K401Form from './components/K401Form';
 import PortfolioChart from './components/PortfolioChart';
 import SummaryCards from './components/SummaryCards';
 import ResultsTable from './components/ResultsTable';
 import { calculateREIT } from './logic/reitCalculator';
 import { calculateRothIRA } from './logic/rothCalculator';
+import { calculate401k } from './logic/k401Calculator';
 
 function App() {
   const [results, setResults] = useState<any>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [expandedSection, setExpandedSection] = useState<string | null>(null);
-  const [calculatorType, setCalculatorType] = useState<'reit' | 'roth'>('reit');
+  const [calculatorType, setCalculatorType] = useState<'reit' | 'roth' | 'k401'>('reit');
   const [reitFormData, setReitFormData] = useState<any>({
     downPayment: 20,
     mortgageRate: 5.5,
@@ -35,6 +37,14 @@ function App() {
     initialBalance: 0,
     annualContribution: 6500,
     annualGrowthRate: 7,
+  });
+  const [k401FormData, setK401FormData] = useState<any>({
+    initialBalance: 0,
+    annualSalary: 60000,
+    employeeContributionPct: 6,
+    employerMatchPct: 50,
+    annualSalaryGrowthRate: 3,
+    annualReturnRate: 7,
   });
 
   const handleCalculate = async (newFormData: any) => {
@@ -61,9 +71,30 @@ function App() {
           },
           detailedAnalysis: calculatedResults.results,
         });
-      } else {
+      } else if (calculatorType === 'roth') {
         setRothFormData(newFormData);
         const calculatedResults = calculateRothIRA(newFormData);
+        setResults({
+          ...calculatedResults.summary,
+          portfolioMetrics: {
+            portfolioComposition: {
+              labels: ['Balance', 'Debt'],
+              values: [calculatedResults.summary.netEquity, 0],
+            },
+            annualCashFlow: {
+              labels: calculatedResults.results.map(r => `Year ${r.year}`),
+              values: calculatedResults.results.map(r => r.annualCashFlow),
+            },
+            equityGrowth: {
+              labels: calculatedResults.results.map(r => `Year ${r.year}`),
+              values: calculatedResults.results.map(r => r.netEquity),
+            },
+          },
+          detailedAnalysis: calculatedResults.results,
+        });
+      } else {
+        setK401FormData(newFormData);
+        const calculatedResults = calculate401k(newFormData);
         setResults({
           ...calculatedResults.summary,
           portfolioMetrics: {
@@ -107,7 +138,11 @@ function App() {
             </div>
             
             <h2 className="text-3xl font-bold bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent mb-4">
-              {calculatorType === 'reit' ? 'Calculating REIT Metrics' : 'Calculating Roth IRA Growth'}
+              {calculatorType === 'reit'
+                ? 'Calculating REIT Metrics'
+                : calculatorType === 'roth'
+                ? 'Calculating Roth IRA Growth'
+                : 'Calculating 401k Growth'}
             </h2>
             <p className="text-slate-300 text-lg mb-4">Analyzing 30-year portfolio performance...</p>
             
@@ -138,7 +173,11 @@ function App() {
             <div className="inline-flex items-center gap-2 bg-slate-800/40 backdrop-blur-sm border border-slate-700/50 rounded-full px-6 py-3 mb-8 shadow-lg">
               <Building2 className="w-5 h-5 text-blue-400" />
               <span className="text-white font-medium">
-                {calculatorType === 'reit' ? 'Advanced REIT Modeling' : 'Roth IRA Growth Calculator'}
+                {calculatorType === 'reit'
+                  ? 'Advanced REIT Modeling'
+                  : calculatorType === 'roth'
+                  ? 'Roth IRA Growth Calculator'
+                  : '401k Growth Calculator'}
               </span>
               <div className="flex items-center ml-2">
                 <Zap className="w-4 h-4 text-yellow-400 animate-pulse mr-1" />
@@ -160,7 +199,11 @@ function App() {
               <div className="text-left">
                 <h1 className="text-7xl md:text-8xl font-black leading-none">
                   <span className="bg-gradient-to-r from-blue-400 via-purple-400 to-cyan-400 bg-clip-text text-transparent">
-                    {calculatorType === 'reit' ? 'REIT' : 'Roth IRA'}
+                    {calculatorType === 'reit'
+                      ? 'REIT'
+                      : calculatorType === 'roth'
+                      ? 'Roth IRA'
+                      : '401k'}
                   </span>
                   <br />
                   <span className="bg-gradient-to-r from-purple-400 via-pink-400 to-blue-400 bg-clip-text text-transparent">
@@ -174,22 +217,60 @@ function App() {
               <p className="text-2xl text-slate-300 leading-relaxed">
                 {calculatorType === 'reit'
                   ? 'Professional-grade modeling for Real Estate Investment Trust portfolios'
-                  : 'Long-term projection of tax-free retirement savings'}
+                  : calculatorType === 'roth'
+                  ? 'Long-term projection of tax-free retirement savings'
+                  : 'Retirement account growth with employer matching'}
               </p>
               
               <div className="flex flex-wrap justify-center gap-4 text-sm">
-                <div className="flex items-center gap-2 bg-slate-800/30 rounded-full px-4 py-2">
-                  <div className="w-2 h-2 bg-green-400 rounded-full"></div>
-                  <span className="text-slate-300">Cash-out Refinancing</span>
-                </div>
-                <div className="flex items-center gap-2 bg-slate-800/30 rounded-full px-4 py-2">
-                  <div className="w-2 h-2 bg-blue-400 rounded-full"></div>
-                  <span className="text-slate-300">1031 Exchanges</span>
-                </div>
-                <div className="flex items-center gap-2 bg-slate-800/30 rounded-full px-4 py-2">
-                  <div className="w-2 h-2 bg-purple-400 rounded-full"></div>
-                  <span className="text-slate-300">Rental Yield Analysis</span>
-                </div>
+                {calculatorType === 'reit' && (
+                  <>
+                    <div className="flex items-center gap-2 bg-slate-800/30 rounded-full px-4 py-2">
+                      <div className="w-2 h-2 bg-green-400 rounded-full"></div>
+                      <span className="text-slate-300">Cash-out Refinancing</span>
+                    </div>
+                    <div className="flex items-center gap-2 bg-slate-800/30 rounded-full px-4 py-2">
+                      <div className="w-2 h-2 bg-blue-400 rounded-full"></div>
+                      <span className="text-slate-300">1031 Exchanges</span>
+                    </div>
+                    <div className="flex items-center gap-2 bg-slate-800/30 rounded-full px-4 py-2">
+                      <div className="w-2 h-2 bg-purple-400 rounded-full"></div>
+                      <span className="text-slate-300">Rental Yield Analysis</span>
+                    </div>
+                  </>
+                )}
+                {calculatorType === 'roth' && (
+                  <>
+                    <div className="flex items-center gap-2 bg-slate-800/30 rounded-full px-4 py-2">
+                      <div className="w-2 h-2 bg-green-400 rounded-full"></div>
+                      <span className="text-slate-300">Tax-Free Growth</span>
+                    </div>
+                    <div className="flex items-center gap-2 bg-slate-800/30 rounded-full px-4 py-2">
+                      <div className="w-2 h-2 bg-blue-400 rounded-full"></div>
+                      <span className="text-slate-300">Consistent Contributions</span>
+                    </div>
+                    <div className="flex items-center gap-2 bg-slate-800/30 rounded-full px-4 py-2">
+                      <div className="w-2 h-2 bg-purple-400 rounded-full"></div>
+                      <span className="text-slate-300">Compound Interest</span>
+                    </div>
+                  </>
+                )}
+                {calculatorType === 'k401' && (
+                  <>
+                    <div className="flex items-center gap-2 bg-slate-800/30 rounded-full px-4 py-2">
+                      <div className="w-2 h-2 bg-green-400 rounded-full"></div>
+                      <span className="text-slate-300">Employer Matching</span>
+                    </div>
+                    <div className="flex items-center gap-2 bg-slate-800/30 rounded-full px-4 py-2">
+                      <div className="w-2 h-2 bg-blue-400 rounded-full"></div>
+                      <span className="text-slate-300">Salary Growth</span>
+                    </div>
+                    <div className="flex items-center gap-2 bg-slate-800/30 rounded-full px-4 py-2">
+                      <div className="w-2 h-2 bg-purple-400 rounded-full"></div>
+                      <span className="text-slate-300">Compounding Returns</span>
+                    </div>
+                  </>
+                )}
               </div>
             </div>
           </div>
@@ -209,6 +290,12 @@ function App() {
               >
                 Roth IRA
               </button>
+              <button
+                onClick={() => setCalculatorType('k401')}
+                className={`px-4 py-2 rounded-full border ${calculatorType === 'k401' ? 'bg-blue-600 border-blue-600' : 'bg-slate-700 border-slate-600'}`}
+              >
+                401k
+              </button>
             </div>
             <div className="bg-slate-800/40 backdrop-blur-sm border border-slate-700/50 rounded-3xl p-8 shadow-2xl">
               <div className="flex items-center gap-3 mb-6">
@@ -218,14 +305,20 @@ function App() {
                 <div>
                   <h2 className="text-2xl font-bold text-white">Investment Calculator</h2>
                   <p className="text-slate-400">
-                    {calculatorType === 'reit' ? 'Configure your REIT portfolio parameters' : 'Configure your Roth IRA inputs'}
+                    {calculatorType === 'reit'
+                      ? 'Configure your REIT portfolio parameters'
+                      : calculatorType === 'roth'
+                      ? 'Configure your Roth IRA inputs'
+                      : 'Configure your 401k assumptions'}
                   </p>
                 </div>
               </div>
               {calculatorType === 'reit' ? (
                 <CalculatorForm onSubmit={handleCalculate} initialData={reitFormData} />
-              ) : (
+              ) : calculatorType === 'roth' ? (
                 <RothIRAForm onSubmit={handleCalculate} initialData={rothFormData} />
+              ) : (
+                <K401Form onSubmit={handleCalculate} initialData={k401FormData} />
               )}
             </div>
           </div>
@@ -332,8 +425,8 @@ function App() {
                       </h3>
                       
                       <p className="text-slate-300 mb-6 text-lg leading-relaxed">
-                        Our comprehensive REIT analysis model incorporates sophisticated financial modeling techniques 
-                        to evaluate portfolio performance across multiple dimensions and risk factors.
+                        Our modeling framework incorporates sophisticated financial techniques
+                        to evaluate a wide range of investment strategies across multiple dimensions and risk factors.
                       </p>
                       
                       <div className="grid md:grid-cols-2 gap-6">
@@ -364,15 +457,15 @@ function App() {
                           <ul className="space-y-3 text-slate-300">
                             <li className="flex items-start gap-3">
                               <div className="w-2 h-2 bg-cyan-400 rounded-full mt-2 flex-shrink-0"></div>
-                              <span>Cash-out refinancing with closing costs</span>
+                              <span>Scenario-based projections</span>
                             </li>
                             <li className="flex items-start gap-3">
                               <div className="w-2 h-2 bg-pink-400 rounded-full mt-2 flex-shrink-0"></div>
-                              <span>1031 tax-deferred exchanges</span>
+                              <span>Tax optimization modeling</span>
                             </li>
                             <li className="flex items-start gap-3">
                               <div className="w-2 h-2 bg-orange-400 rounded-full mt-2 flex-shrink-0"></div>
-                              <span>Detailed rental yield calculations</span>
+                              <span>Contribution & withdrawal strategies</span>
                             </li>
                             <li className="flex items-start gap-3">
                               <div className="w-2 h-2 bg-red-400 rounded-full mt-2 flex-shrink-0"></div>

--- a/src/components/K401Form.tsx
+++ b/src/components/K401Form.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { DollarSign, Percent } from 'lucide-react';
+
+export interface K401FormProps {
+  onSubmit: (formData: any) => void;
+  initialData?: any;
+}
+
+const K401Form: React.FC<K401FormProps> = ({ onSubmit, initialData }) => {
+  const [formData, setFormData] = React.useState({
+    initialBalance: initialData?.initialBalance ?? 0,
+    annualSalary: initialData?.annualSalary ?? 60000,
+    employeeContributionPct: initialData?.employeeContributionPct ?? 6,
+    employerMatchPct: initialData?.employerMatchPct ?? 50,
+    annualSalaryGrowthRate: initialData?.annualSalaryGrowthRate ?? 3,
+    annualReturnRate: initialData?.annualReturnRate ?? 7,
+  });
+
+  const handleChange = (field: string, value: string | number) => {
+    setFormData(prev => ({
+      ...prev,
+      [field]: value === '' ? '' : Number(value)
+    }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit(formData);
+  };
+
+  const inputClasses = "w-full bg-slate-800/40 border border-slate-700/50 rounded-xl px-4 py-3 text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-transparent transition-all";
+  const labelClasses = "block text-sm font-medium text-slate-300 mb-2";
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-8">
+      <div className="grid md:grid-cols-2 gap-6">
+        <div>
+          <label className={labelClasses}>
+            <div className="flex items-center gap-2">
+              <DollarSign className="w-4 h-4 text-yellow-400" />
+              Initial Balance
+            </div>
+          </label>
+          <input
+            type="number"
+            value={formData.initialBalance}
+            onChange={e => handleChange('initialBalance', e.target.value)}
+            className={inputClasses}
+            step="100"
+            min="0"
+          />
+        </div>
+        <div>
+          <label className={labelClasses}>
+            <div className="flex items-center gap-2">
+              <DollarSign className="w-4 h-4 text-green-400" />
+              Annual Salary
+            </div>
+          </label>
+          <input
+            type="number"
+            value={formData.annualSalary}
+            onChange={e => handleChange('annualSalary', e.target.value)}
+            className={inputClasses}
+            step="1000"
+            min="0"
+          />
+        </div>
+        <div>
+          <label className={labelClasses}>
+            <div className="flex items-center gap-2">
+              <Percent className="w-4 h-4 text-blue-400" />
+              Employee Contribution %
+            </div>
+          </label>
+          <input
+            type="number"
+            value={formData.employeeContributionPct}
+            onChange={e => handleChange('employeeContributionPct', e.target.value)}
+            className={inputClasses}
+            step="0.1"
+            min="0"
+            max="100"
+          />
+        </div>
+        <div>
+          <label className={labelClasses}>
+            <div className="flex items-center gap-2">
+              <Percent className="w-4 h-4 text-purple-400" />
+              Employer Match %
+            </div>
+          </label>
+          <input
+            type="number"
+            value={formData.employerMatchPct}
+            onChange={e => handleChange('employerMatchPct', e.target.value)}
+            className={inputClasses}
+            step="1"
+            min="0"
+            max="100"
+          />
+        </div>
+        <div>
+          <label className={labelClasses}>
+            <div className="flex items-center gap-2">
+              <Percent className="w-4 h-4 text-cyan-400" />
+              Annual Salary Growth %
+            </div>
+          </label>
+          <input
+            type="number"
+            value={formData.annualSalaryGrowthRate}
+            onChange={e => handleChange('annualSalaryGrowthRate', e.target.value)}
+            className={inputClasses}
+            step="0.1"
+            min="0"
+          />
+        </div>
+        <div>
+          <label className={labelClasses}>
+            <div className="flex items-center gap-2">
+              <Percent className="w-4 h-4 text-teal-400" />
+              Annual Return Rate
+            </div>
+          </label>
+          <input
+            type="number"
+            value={formData.annualReturnRate}
+            onChange={e => handleChange('annualReturnRate', e.target.value)}
+            className={inputClasses}
+            step="0.1"
+            min="0"
+          />
+        </div>
+      </div>
+      <button
+        type="submit"
+        className="w-full bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white font-semibold py-4 px-6 rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+      >
+        Calculate Growth
+      </button>
+    </form>
+  );
+};
+
+export default K401Form;

--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -16,7 +16,7 @@ export interface YearlyResult {
 
 export interface ResultsTableProps {
   results: YearlyResult[];
-  calculatorType: 'reit' | 'roth';
+  calculatorType: 'reit' | 'roth' | 'k401';
 }
 
 type Order = 'asc' | 'desc';

--- a/src/components/SummaryCards.tsx
+++ b/src/components/SummaryCards.tsx
@@ -11,7 +11,7 @@ export interface SummaryCardsProps {
     annualizedReturn: number;
     equityMultiple: number;
   };
-  calculatorType: 'reit' | 'roth';
+  calculatorType: 'reit' | 'roth' | 'k401';
 }
 
 const SummaryCards: React.FC<SummaryCardsProps> = ({ results, calculatorType }) => {

--- a/src/logic/k401Calculator.ts
+++ b/src/logic/k401Calculator.ts
@@ -1,0 +1,53 @@
+export interface K401Inputs {
+  initialBalance: number;
+  annualSalary: number;
+  employeeContributionPct: number; // percent of salary
+  employerMatchPct: number; // percent of employee contribution
+  annualSalaryGrowthRate: number; // percent
+  annualReturnRate: number; // percent
+}
+
+import { YearlyResult } from '../components/ResultsTable';
+import { REITCalculatorSummary } from './reitCalculator';
+
+export function calculate401k(inputs: K401Inputs): { results: YearlyResult[]; summary: REITCalculatorSummary } {
+  const { initialBalance, annualSalary, employeeContributionPct, employerMatchPct, annualSalaryGrowthRate, annualReturnRate } = inputs;
+  let balance = initialBalance;
+  let salary = annualSalary;
+  let totalContributions = initialBalance;
+  const results: YearlyResult[] = [];
+  for (let year = 1; year <= 30; year++) {
+    const employeeContribution = salary * (employeeContributionPct / 100);
+    const employerContribution = employeeContribution * (employerMatchPct / 100);
+    const totalContribution = employeeContribution + employerContribution;
+    balance = (balance + totalContribution) * (1 + annualReturnRate / 100);
+    totalContributions += totalContribution;
+    const roi = totalContributions > 0 ? ((balance - totalContributions) / totalContributions) * 100 : 0;
+    results.push({
+      year,
+      propertyCount: 0,
+      action: '',
+      totalValue: balance,
+      totalDebt: 0,
+      netEquity: balance,
+      annualCashFlow: totalContribution,
+      cashBalance: totalContributions,
+      totalDebtService: 0,
+      roi,
+    });
+    salary *= 1 + annualSalaryGrowthRate / 100;
+  }
+  const final = results[results.length - 1];
+  const annualizedReturn = initialBalance > 0 ? (Math.pow(final.totalValue / initialBalance, 1 / 30) - 1) * 100 : 0;
+  const summary: REITCalculatorSummary = {
+    propertyCount: 0,
+    portfolioValue: final.totalValue,
+    netEquity: final.netEquity,
+    totalDebt: 0,
+    roi: final.roi,
+    cashExtracted: totalContributions,
+    annualizedReturn,
+    equityMultiple: totalContributions > 0 ? final.totalValue / totalContributions : 0,
+  };
+  return { results, summary };
+}


### PR DESCRIPTION
## Summary
- update site title and description
- support new 401k calculator and generic methodology
- adjust hero sections and feature lists for all calculators
- update results and summary components for new type
- document new multi-calculator capabilities

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68426fc2eebc8320bc2bc657e6f3d35a