### PR TITLE
Fix analyzer heading and add brokerage tags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -289,7 +289,11 @@ function App() {
                       ? 'REIT'
                       : calculatorType === 'roth'
                       ? 'Roth IRA'
-                      : '401k'}
+                      : calculatorType === 'k401'
+                      ? '401k'
+                      : calculatorType === 'brokerage'
+                      ? 'Brokerage'
+                      : 'HSA'}
                   </span>
                   <br />
                   <span className="bg-gradient-to-r from-purple-400 via-pink-400 to-blue-400 bg-clip-text text-transparent">
@@ -354,6 +358,22 @@ function App() {
                     <div className="flex items-center gap-2 bg-slate-800/30 rounded-full px-4 py-2">
                       <div className="w-2 h-2 bg-purple-400 rounded-full"></div>
                       <span className="text-slate-300">Compounding Returns</span>
+                    </div>
+                  </>
+                )}
+                {calculatorType === 'brokerage' && (
+                  <>
+                    <div className="flex items-center gap-2 bg-slate-800/30 rounded-full px-4 py-2">
+                      <div className="w-2 h-2 bg-green-400 rounded-full"></div>
+                      <span className="text-slate-300">Tax-Efficient Investing</span>
+                    </div>
+                    <div className="flex items-center gap-2 bg-slate-800/30 rounded-full px-4 py-2">
+                      <div className="w-2 h-2 bg-blue-400 rounded-full"></div>
+                      <span className="text-slate-300">Capital Gains Management</span>
+                    </div>
+                    <div className="flex items-center gap-2 bg-slate-800/30 rounded-full px-4 py-2">
+                      <div className="w-2 h-2 bg-purple-400 rounded-full"></div>
+                      <span className="text-slate-300">Dividend Reinvestment</span>
                     </div>
                   </>
                 )}


### PR DESCRIPTION
## Summary
- fix hero heading to show correct name for Brokerage and HSA
- add brokerage highlight tags in hero section

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e15c0ee483208d9f90c7107a7182