### PR TITLE
Fix contribution tracking across calculators

### DIFF
--- a/src/logic/brokerageCalculator.ts
+++ b/src/logic/brokerageCalculator.ts
@@ -13,7 +13,7 @@ export interface BrokerageInputs {
 export function calculateBrokerage(inputs: BrokerageInputs): { results: YearlyResult[]; summary: REITCalculatorSummary } {
   const { initialBalance, contributionAmount, contributionFrequency, annualReturnRate, taxRate, years } = inputs;
   let balance = initialBalance;
-  let totalContributions = initialBalance;
+  let totalContributions = 0;
   const results: YearlyResult[] = [];
 
   if (contributionFrequency === 'monthly') {
@@ -23,7 +23,8 @@ export function calculateBrokerage(inputs: BrokerageInputs): { results: YearlyRe
       totalContributions += contributionAmount;
       if (month % 12 === 0) {
         const year = month / 12;
-        const roi = totalContributions > 0 ? ((balance - totalContributions) / totalContributions) * 100 : 0;
+        const invested = initialBalance + totalContributions;
+        const roi = invested > 0 ? ((balance - invested) / invested) * 100 : 0;
         results.push({
           year,
           propertyCount: 0,
@@ -32,7 +33,7 @@ export function calculateBrokerage(inputs: BrokerageInputs): { results: YearlyRe
           totalDebt: 0,
           netEquity: balance,
           annualCashFlow: contributionAmount * 12,
-          cashBalance: totalContributions,
+          cashBalance: initialBalance + totalContributions,
           totalDebtService: 0,
           roi,
         });
@@ -42,7 +43,8 @@ export function calculateBrokerage(inputs: BrokerageInputs): { results: YearlyRe
     for (let year = 1; year <= years; year++) {
       balance = (balance + contributionAmount) * (1 + annualReturnRate / 100);
       totalContributions += contributionAmount;
-      const roi = totalContributions > 0 ? ((balance - totalContributions) / totalContributions) * 100 : 0;
+      const invested = initialBalance + totalContributions;
+      const roi = invested > 0 ? ((balance - invested) / invested) * 100 : 0;
       results.push({
         year,
         propertyCount: 0,
@@ -51,7 +53,7 @@ export function calculateBrokerage(inputs: BrokerageInputs): { results: YearlyRe
         totalDebt: 0,
         netEquity: balance,
         annualCashFlow: contributionAmount,
-        cashBalance: totalContributions,
+        cashBalance: initialBalance + totalContributions,
         totalDebtService: 0,
         roi,
       });
@@ -60,7 +62,8 @@ export function calculateBrokerage(inputs: BrokerageInputs): { results: YearlyRe
 
   const final = results[results.length - 1];
   const afterTax = balance * (1 - taxRate / 100);
-  const roi = totalContributions > 0 ? ((afterTax - totalContributions) / totalContributions) * 100 : 0;
+  const totalInvested = initialBalance + totalContributions;
+  const roi = totalInvested > 0 ? ((afterTax - totalInvested) / totalInvested) * 100 : 0;
   const annualizedReturn = initialBalance > 0 ? (Math.pow(afterTax / initialBalance, 1 / years) - 1) * 100 : 0;
   const summary: REITCalculatorSummary = {
     propertyCount: 0,
@@ -70,7 +73,7 @@ export function calculateBrokerage(inputs: BrokerageInputs): { results: YearlyRe
     roi,
     cashExtracted: totalContributions,
     annualizedReturn,
-    equityMultiple: totalContributions > 0 ? afterTax / totalContributions : 0,
+    equityMultiple: totalInvested > 0 ? afterTax / totalInvested : 0,
     years,
   };
 

--- a/src/logic/hsaCalculator.ts
+++ b/src/logic/hsaCalculator.ts
@@ -12,14 +12,15 @@ import { REITCalculatorSummary } from './reitCalculator';
 export function calculateHSA(inputs: HSAInputs): { results: YearlyResult[]; summary: REITCalculatorSummary } {
   const { initialBalance, annualContribution, annualMedicalExpenses, annualGrowthRate, years } = inputs;
   let balance = initialBalance;
-  let totalContributions = initialBalance;
+  let totalContributions = 0;
   let totalWithdrawals = 0;
   const results: YearlyResult[] = [];
   for (let year = 1; year <= years; year++) {
     balance = (balance + annualContribution - annualMedicalExpenses) * (1 + annualGrowthRate / 100);
     totalContributions += annualContribution;
     totalWithdrawals += annualMedicalExpenses;
-    const roi = totalContributions > 0 ? ((balance + totalWithdrawals - totalContributions) / totalContributions) * 100 : 0;
+    const invested = initialBalance + totalContributions;
+    const roi = invested > 0 ? ((balance + totalWithdrawals - invested) / invested) * 100 : 0;
     results.push({
       year,
       propertyCount: 0,
@@ -28,13 +29,14 @@ export function calculateHSA(inputs: HSAInputs): { results: YearlyResult[]; summ
       totalDebt: 0,
       netEquity: balance,
       annualCashFlow: annualContribution - annualMedicalExpenses,
-      cashBalance: totalContributions - totalWithdrawals,
+      cashBalance: initialBalance + totalContributions - totalWithdrawals,
       totalDebtService: 0,
       roi,
     });
   }
   const final = results[results.length - 1];
-  const roiFinal = totalContributions > 0 ? ((final.netEquity + totalWithdrawals - totalContributions) / totalContributions) * 100 : 0;
+  const totalInvested = initialBalance + totalContributions;
+  const roiFinal = totalInvested > 0 ? ((final.netEquity + totalWithdrawals - totalInvested) / totalInvested) * 100 : 0;
   const annualizedReturn = initialBalance > 0 ? (Math.pow(final.netEquity / initialBalance, 1 / years) - 1) * 100 : 0;
   const summary: REITCalculatorSummary = {
     propertyCount: 0,
@@ -44,7 +46,7 @@ export function calculateHSA(inputs: HSAInputs): { results: YearlyResult[]; summ
     roi: roiFinal,
     cashExtracted: totalContributions,
     annualizedReturn,
-    equityMultiple: totalContributions > 0 ? (final.netEquity + totalWithdrawals) / totalContributions : 0,
+    equityMultiple: totalInvested > 0 ? (final.netEquity + totalWithdrawals) / totalInvested : 0,
     years,
   };
   return { results, summary };

--- a/src/logic/k401Calculator.ts
+++ b/src/logic/k401Calculator.ts
@@ -16,7 +16,7 @@ export function calculate401k(inputs: K401Inputs): { results: YearlyResult[]; su
   const { initialBalance, annualSalary, employeeContributionPct, employerMatchPct, annualSalaryGrowthRate, annualReturnRate, taxRate, years } = inputs;
   let balance = initialBalance;
   let salary = annualSalary;
-  let totalContributions = initialBalance;
+  let totalContributions = 0;
   const results: YearlyResult[] = [];
   for (let year = 1; year <= years; year++) {
     const employeeContribution = salary * (employeeContributionPct / 100);
@@ -24,7 +24,8 @@ export function calculate401k(inputs: K401Inputs): { results: YearlyResult[]; su
     const totalContribution = employeeContribution + employerContribution;
     balance = (balance + totalContribution) * (1 + annualReturnRate / 100);
     totalContributions += totalContribution;
-    const roi = totalContributions > 0 ? ((balance - totalContributions) / totalContributions) * 100 : 0;
+    const invested = initialBalance + totalContributions;
+    const roi = invested > 0 ? ((balance - invested) / invested) * 100 : 0;
     results.push({
       year,
       propertyCount: 0,
@@ -33,7 +34,7 @@ export function calculate401k(inputs: K401Inputs): { results: YearlyResult[]; su
       totalDebt: 0,
       netEquity: balance,
       annualCashFlow: totalContribution,
-      cashBalance: totalContributions,
+      cashBalance: initialBalance + totalContributions,
       totalDebtService: 0,
       roi,
     });
@@ -41,7 +42,8 @@ export function calculate401k(inputs: K401Inputs): { results: YearlyResult[]; su
   }
   const final = results[results.length - 1];
   const afterTax = final.totalValue * (1 - taxRate / 100);
-  const roiAfterTax = totalContributions > 0 ? ((afterTax - totalContributions) / totalContributions) * 100 : 0;
+  const totalInvested = initialBalance + totalContributions;
+  const roiAfterTax = totalInvested > 0 ? ((afterTax - totalInvested) / totalInvested) * 100 : 0;
   const annualizedReturn = initialBalance > 0 ? (Math.pow(afterTax / initialBalance, 1 / years) - 1) * 100 : 0;
   const summary: REITCalculatorSummary = {
     propertyCount: 0,
@@ -51,7 +53,7 @@ export function calculate401k(inputs: K401Inputs): { results: YearlyResult[]; su
     roi: roiAfterTax,
     cashExtracted: totalContributions,
     annualizedReturn,
-    equityMultiple: totalContributions > 0 ? afterTax / totalContributions : 0,
+    equityMultiple: totalInvested > 0 ? afterTax / totalInvested : 0,
     years,
   };
   return { results, summary };

--- a/src/logic/rothCalculator.ts
+++ b/src/logic/rothCalculator.ts
@@ -11,12 +11,13 @@ import { REITCalculatorSummary } from './reitCalculator';
 export function calculateRothIRA(inputs: RothIRAInputs): { results: YearlyResult[]; summary: REITCalculatorSummary } {
   const { initialBalance, annualContribution, annualGrowthRate, years } = inputs;
   let balance = initialBalance;
-  let totalContributions = initialBalance;
+  let totalContributions = 0;
   const results: YearlyResult[] = [];
   for (let year = 1; year <= years; year++) {
     balance = (balance + annualContribution) * (1 + annualGrowthRate / 100);
     totalContributions += annualContribution;
-    const roi = totalContributions > 0 ? ((balance - totalContributions) / totalContributions) * 100 : 0;
+    const invested = initialBalance + totalContributions;
+    const roi = invested > 0 ? ((balance - invested) / invested) * 100 : 0;
     results.push({
       year,
       propertyCount: 0,
@@ -25,14 +26,15 @@ export function calculateRothIRA(inputs: RothIRAInputs): { results: YearlyResult
       totalDebt: 0,
       netEquity: balance,
       annualCashFlow: annualContribution,
-      cashBalance: totalContributions,
+      cashBalance: initialBalance + totalContributions,
       totalDebtService: 0,
       roi,
     });
   }
   const final = results[results.length - 1];
   const afterTax = final.totalValue;
-  const roiAfterTax = totalContributions > 0 ? ((afterTax - totalContributions) / totalContributions) * 100 : 0;
+  const totalInvested = initialBalance + totalContributions;
+  const roiAfterTax = totalInvested > 0 ? ((afterTax - totalInvested) / totalInvested) * 100 : 0;
   const annualizedReturn = initialBalance > 0 ? (Math.pow(afterTax / initialBalance, 1 / years) - 1) * 100 : 0;
   const summary: REITCalculatorSummary = {
     propertyCount: 0,
@@ -42,7 +44,7 @@ export function calculateRothIRA(inputs: RothIRAInputs): { results: YearlyResult
     roi: roiAfterTax,
     cashExtracted: totalContributions, // reuse field to show total contributions
     annualizedReturn,
-    equityMultiple: totalContributions > 0 ? afterTax / totalContributions : 0,
+    equityMultiple: totalInvested > 0 ? afterTax / totalInvested : 0,
     years,
   };
   return { results, summary };


### PR DESCRIPTION
## Summary
- ensure calculators track contributions separately from the initial balance
- compute ROI and equity multiple using invested capital

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6842e3f522c4832098599309a4170dc6