### PR TITLE
Add shareable scenarios and styled toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,11 +13,13 @@ import { calculateRothIRA } from './logic/rothCalculator';
 import { calculate401k } from './logic/k401Calculator';
 import { calculateBrokerage } from './logic/brokerageCalculator';
 import { calculateHSA } from './logic/hsaCalculator';
+import { buildShareLink, parseQuery } from './utils/shareLink';
 
 function App() {
   const [results, setResults] = useState<any>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [expandedSection, setExpandedSection] = useState<string | null>(null);
+  const [shareCopied, setShareCopied] = useState(false);
   const [calculatorType, setCalculatorType] = useState<'reit' | 'roth' | 'k401' | 'brokerage' | 'hsa'>('reit');
   const [reitFormData, setReitFormData] = useState<any>({
     downPayment: 20,
@@ -200,6 +202,35 @@ function App() {
       setIsLoading(false);
     }
   };
+
+  React.useEffect(() => {
+    const { calculatorType: calc, formData } = parseQuery();
+    if (calc) {
+      setCalculatorType(calc as any);
+      if (calc === 'reit') {
+        const data = { ...reitFormData, ...formData };
+        setReitFormData(data);
+        handleCalculate(data);
+      } else if (calc === 'roth') {
+        const data = { ...rothFormData, ...formData };
+        setRothFormData(data);
+        handleCalculate(data);
+      } else if (calc === 'k401') {
+        const data = { ...k401FormData, ...formData };
+        setK401FormData(data);
+        handleCalculate(data);
+      } else if (calc === 'brokerage') {
+        const data = { ...brokerageFormData, ...formData };
+        setBrokerageFormData(data);
+        handleCalculate(data);
+      } else if (calc === 'hsa') {
+        const data = { ...hsaFormData, ...formData };
+        setHsaFormData(data);
+        handleCalculate(data);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (isLoading) {
     return (
@@ -470,10 +501,36 @@ function App() {
       {/* Results Section */}
       {results && (
         <div className="relative container mx-auto px-6 pb-20">
-          {/* Summary Cards */}
-          <div className="mb-12">
-            <SummaryCards results={results} calculatorType={calculatorType} />
-          </div>
+            {/* Summary Cards */}
+            <div className="mb-12">
+              <SummaryCards results={results} calculatorType={calculatorType} />
+              <div className="mt-4 flex justify-end">
+                <button
+                  onClick={() => {
+                    const data =
+                      calculatorType === 'reit'
+                        ? reitFormData
+                        : calculatorType === 'roth'
+                        ? rothFormData
+                        : calculatorType === 'k401'
+                        ? k401FormData
+                        : calculatorType === 'brokerage'
+                        ? brokerageFormData
+                        : hsaFormData;
+                    const link = buildShareLink(calculatorType, data);
+                    navigator.clipboard.writeText(link);
+                    setShareCopied(true);
+                    setTimeout(() => setShareCopied(false), 2000);
+                  }}
+                  className="bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium px-4 py-2 rounded-full shadow"
+                >
+                  Share Scenario
+                </button>
+                {shareCopied && (
+                  <span className="ml-3 text-sm text-green-400">Link copied!</span>
+                )}
+              </div>
+            </div>
 
           {/* Expandable Sections */}
           <div className="space-y-6">

--- a/src/components/CalculatorForm.tsx
+++ b/src/components/CalculatorForm.tsx
@@ -244,32 +244,21 @@ const CalculatorForm: React.FC<CalculatorFormProps> = ({ onSubmit, initialData }
         </div>
 
         <div className="mb-6">
-          <div className="flex items-center gap-4 p-4 bg-slate-800/30 rounded-xl border border-slate-700/30">
-            <div className="flex items-center gap-2">
-              <input
-                type="radio"
-                id="itemized"
-                name="yieldMode"
-                value="itemized"
-                checked={formData.yieldMode === 'itemized'}
-                onChange={(e) => handleChange('yieldMode', e.target.value)}
-                className="w-4 h-4 text-blue-500 border-slate-600 focus:ring-blue-500 bg-slate-800 checked:bg-blue-500 checked:border-blue-500"
-              />
-              <label htmlFor="itemized" className="text-white">Itemized Yield Inputs</label>
-            </div>
-
-            <div className="flex items-center gap-2">
-              <input
-                type="radio"
-                id="net"
-                name="yieldMode"
-                value="net"
-                checked={formData.yieldMode === 'net'}
-                onChange={(e) => handleChange('yieldMode', e.target.value)}
-                className="w-4 h-4 text-blue-500 border-slate-600 focus:ring-blue-500 bg-slate-800 checked:bg-blue-500 checked:border-blue-500"
-              />
-              <label htmlFor="net" className="text-white">Net Yield Input</label>
-            </div>
+          <div className="flex items-center justify-center bg-slate-800/30 rounded-full p-1 border border-slate-700/30">
+            <button
+              type="button"
+              onClick={() => handleChange('yieldMode', 'itemized')}
+              className={`flex-1 py-2 rounded-full text-sm font-medium transition-colors duration-200 ${formData.yieldMode === 'itemized' ? 'bg-blue-600 text-white shadow' : 'text-slate-300 hover:bg-slate-700/30'}`}
+            >
+              Itemized Inputs
+            </button>
+            <button
+              type="button"
+              onClick={() => handleChange('yieldMode', 'net')}
+              className={`flex-1 py-2 rounded-full text-sm font-medium transition-colors duration-200 ${formData.yieldMode === 'net' ? 'bg-blue-600 text-white shadow' : 'text-slate-300 hover:bg-slate-700/30'}`}
+            >
+              Net Yield Input
+            </button>
           </div>
         </div>
 

--- a/src/utils/shareLink.ts
+++ b/src/utils/shareLink.ts
@@ -1,0 +1,20 @@
+export function buildShareLink(calculatorType: string, formData: Record<string, any>): string {
+  const params = new URLSearchParams();
+  params.set('calc', calculatorType);
+  Object.entries(formData).forEach(([key, value]) => {
+    params.set(key, String(value));
+  });
+  return `${window.location.origin}${window.location.pathname}?${params.toString()}`;
+}
+
+export function parseQuery(): { calculatorType: string | null; formData: Record<string, any> } {
+  const params = new URLSearchParams(window.location.search);
+  const calc = params.get('calc');
+  const data: Record<string, any> = {};
+  params.forEach((value, key) => {
+    if (key === 'calc') return;
+    const num = Number(value);
+    data[key] = isNaN(num) ? value : num;
+  });
+  return { calculatorType: calc, formData: data };
+}


### PR DESCRIPTION
## Summary
- refine rental yield chooser with button-style toggle
- add utilities to create and parse shareable links
- persist scenarios from URL query and copy link on demand

## Testing
- `npm install`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6843ab53f3c48320a6bdd0891b09d1f2