### PR TITLE
Add plan management and help popovers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,8 @@
 import React, { useState } from 'react';
 import { Building2, Calculator, ChartBar, TrendingUp, ChevronDown, ChevronUp, Info, Zap, Activity, Share2 } from 'lucide-react';
+import PlanSidebar from './components/PlanSidebar';
+import { Plan, PlanResult } from './types';
+import ComparisonChart from './components/ComparisonChart';
 import CalculatorForm from './components/CalculatorForm';
 import RothIRAForm from './components/RothIRAForm';
 import K401Form from './components/K401Form';
@@ -71,6 +74,21 @@ function App() {
     annualGrowthRate: 7,
     years: 30,
   });
+
+  const [savedPlans, setSavedPlans] = useState<Plan[]>([]);
+  const [showPlans, setShowPlans] = useState(false);
+  const [comparePlans, setComparePlans] = useState<PlanResult[] | null>(null);
+
+  React.useEffect(() => {
+    const stored = localStorage.getItem('savedPlans');
+    if (stored) {
+      setSavedPlans(JSON.parse(stored));
+    }
+  }, []);
+
+  React.useEffect(() => {
+    localStorage.setItem('savedPlans', JSON.stringify(savedPlans));
+  }, [savedPlans]);
 
   React.useEffect(() => {
     setResults(null);
@@ -203,6 +221,54 @@ function App() {
     }
   };
 
+  const handleSavePlan = () => {
+    const name = prompt('Plan name');
+    if (!name) return;
+    const formData =
+      calculatorType === 'reit'
+        ? reitFormData
+        : calculatorType === 'roth'
+        ? rothFormData
+        : calculatorType === 'k401'
+        ? k401FormData
+        : calculatorType === 'brokerage'
+        ? brokerageFormData
+        : hsaFormData;
+    const newPlan: Plan = { name, calculatorType, formData };
+    setSavedPlans(prev => [...prev.filter(p => p.name !== name), newPlan]);
+  };
+
+  const loadPlan = (plan: Plan) => {
+    setCalculatorType(plan.calculatorType);
+    const data = plan.formData;
+    if (plan.calculatorType === 'reit') setReitFormData(data);
+    else if (plan.calculatorType === 'roth') setRothFormData(data);
+    else if (plan.calculatorType === 'k401') setK401FormData(data);
+    else if (plan.calculatorType === 'brokerage') setBrokerageFormData(data);
+    else setHsaFormData(data);
+    handleCalculate(data);
+  };
+
+  const deletePlan = (name: string) => {
+    setSavedPlans(prev => prev.filter(p => p.name !== name));
+  };
+
+  const comparePlanResults = (a: Plan, b: Plan) => {
+    const calcFor = async (plan: Plan) => {
+      if (plan.calculatorType === 'reit') return calculateREIT(plan.formData);
+      if (plan.calculatorType === 'roth') return calculateRothIRA(plan.formData);
+      if (plan.calculatorType === 'k401') return calculate401k(plan.formData);
+      if (plan.calculatorType === 'brokerage') return calculateBrokerage(plan.formData);
+      return calculateHSA(plan.formData);
+    };
+    Promise.all([calcFor(a), calcFor(b)]).then(([resA, resB]) => {
+      setComparePlans([
+        { plan: a, result: resA },
+        { plan: b, result: resB }
+      ]);
+    });
+  };
+
   React.useEffect(() => {
     const { calculatorType: calc, formData } = parseQuery();
     if (calc) {
@@ -273,6 +339,22 @@ function App() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 text-white">
+      <button
+        onClick={() => setShowPlans(true)}
+        className="fixed top-4 right-4 z-30 bg-blue-600 hover:bg-blue-700 text-white text-sm px-4 py-2 rounded"
+      >
+        My Plans
+      </button>
+      {showPlans && (
+        <PlanSidebar
+          plans={savedPlans}
+          open={showPlans}
+          onClose={() => setShowPlans(false)}
+          onLoad={loadPlan}
+          onDelete={deletePlan}
+          onCompare={comparePlanResults}
+        />
+      )}
       {/* Animated Background Elements */}
       <div className="fixed inset-0 overflow-hidden pointer-events-none">
         <div className="absolute -top-40 -right-40 w-80 h-80 bg-blue-500/10 rounded-full blur-3xl animate-pulse"></div>
@@ -504,7 +586,7 @@ function App() {
             {/* Summary Cards */}
             <div className="mb-12">
               <SummaryCards results={results} calculatorType={calculatorType} />
-              <div className="mt-4 flex justify-end">
+              <div className="mt-4 flex justify-end space-x-3">
                 <button
                   onClick={() => {
                     const data =
@@ -527,11 +609,52 @@ function App() {
                   <Share2 className="w-4 h-4" />
                   <span>Share Scenario</span>
                 </button>
+                <button
+                  onClick={handleSavePlan}
+                  className="flex items-center gap-2 bg-slate-700 hover:bg-slate-600 text-white text-sm font-medium px-4 py-2 rounded-full"
+                >
+                  Save Plan
+                </button>
                 {shareCopied && (
-                  <span className="ml-3 text-sm text-green-400">Link copied!</span>
+                  <span className="text-sm text-green-400">Link copied!</span>
                 )}
               </div>
             </div>
+
+          {comparePlans && (
+            <div className="mb-12">
+              <h3 className="text-xl font-semibold mb-4 text-white">Comparison</h3>
+              <ComparisonChart
+                labels={comparePlans[0].result.results.map((r: any) => `Year ${r.year}`)}
+                datasets={[
+                  {
+                    label: comparePlans[0].plan.name,
+                    data: comparePlans[0].result.results.map((r: any) => r.netEquity),
+                    borderColor: 'rgba(99,102,241,1)'
+                  },
+                  {
+                    label: comparePlans[1].plan.name,
+                    data: comparePlans[1].result.results.map((r: any) => r.netEquity),
+                    borderColor: 'rgba(236,72,153,1)'
+                  }
+                ]}
+              />
+              <div className="mt-4 grid grid-cols-2 gap-4 text-sm text-slate-200">
+                <div className="bg-slate-800/40 p-4 rounded-xl">
+                  <div className="font-semibold mb-2">{comparePlans[0].plan.name}</div>
+                  <div>Final Value: ${comparePlans[0].result.summary.netEquity.toLocaleString()}</div>
+                  <div>Total Contributions: ${comparePlans[0].result.summary.cashExtracted.toLocaleString()}</div>
+                  <div>Total Interest: ${(comparePlans[0].result.summary.netEquity - comparePlans[0].result.summary.cashExtracted).toLocaleString()}</div>
+                </div>
+                <div className="bg-slate-800/40 p-4 rounded-xl">
+                  <div className="font-semibold mb-2">{comparePlans[1].plan.name}</div>
+                  <div>Final Value: ${comparePlans[1].result.summary.netEquity.toLocaleString()}</div>
+                  <div>Total Contributions: ${comparePlans[1].result.summary.cashExtracted.toLocaleString()}</div>
+                  <div>Total Interest: ${(comparePlans[1].result.summary.netEquity - comparePlans[1].result.summary.cashExtracted).toLocaleString()}</div>
+                </div>
+              </div>
+            </div>
+          )}
 
           {/* Expandable Sections */}
           <div className="space-y-6">

--- a/src/components/BrokerageForm.tsx
+++ b/src/components/BrokerageForm.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DollarSign, Percent, Calendar } from 'lucide-react';
+import HelpPopover from './HelpPopover';
 
 export interface BrokerageFormProps {
   onSubmit: (formData: any) => void;
@@ -82,6 +83,11 @@ const BrokerageForm: React.FC<BrokerageFormProps> = ({ onSubmit, initialData }) 
             <div className="flex items-center gap-2">
               <Percent className="w-4 h-4 text-blue-400" />
               Annual Return Rate
+              <HelpPopover
+                explanation="The average annual return you expect from this fund. Historically, the S&P 500 has averaged around 10%."
+                presets={[5,7,10]}
+                onSelect={val => handleChange('annualReturnRate', val)}
+              />
             </div>
           </label>
           <input

--- a/src/components/ComparisonChart.tsx
+++ b/src/components/ComparisonChart.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend
+} from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
+
+interface Dataset {
+  label: string;
+  data: number[];
+  borderColor: string;
+}
+
+interface Props {
+  labels: string[];
+  datasets: Dataset[];
+}
+
+const ComparisonChart: React.FC<Props> = ({ labels, datasets }) => {
+  return (
+    <div className="h-[300px]">
+      <Line
+        data={{ labels, datasets }}
+        options={{
+          responsive: true,
+          plugins: {
+            legend: {
+              labels: { color: '#94a3b8', font: { family: "'Inter', sans-serif", size: 12 } }
+            }
+          },
+          scales: {
+            x: { ticks: { color: '#94a3b8' }, grid: { color: 'rgba(148,163,184,0.1)' } },
+            y: {
+              ticks: { color: '#94a3b8', callback: (v: any) => '$' + (v/1000000).toFixed(1) + 'M' },
+              grid: { color: 'rgba(148,163,184,0.1)' }
+            }
+          }
+        }}
+      />
+    </div>
+  );
+};
+
+export default ComparisonChart;

--- a/src/components/HSAForm.tsx
+++ b/src/components/HSAForm.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DollarSign, Percent, Calendar, Stethoscope } from 'lucide-react';
+import HelpPopover from './HelpPopover';
 
 export interface HSAFormProps {
   onSubmit: (formData: any) => void;
@@ -86,6 +87,11 @@ const HSAForm: React.FC<HSAFormProps> = ({ onSubmit, initialData }) => {
             <div className="flex items-center gap-2">
               <Percent className="w-4 h-4 text-blue-400" />
               Annual Growth Rate
+              <HelpPopover
+                explanation="The average annual return you expect from this fund. Historically, the S&P 500 has averaged around 10%."
+                presets={[5,7,10]}
+                onSelect={val => handleChange('annualGrowthRate', val)}
+              />
             </div>
           </label>
           <input

--- a/src/components/HelpPopover.tsx
+++ b/src/components/HelpPopover.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { HelpCircle } from 'lucide-react';
+
+interface Props {
+  explanation: string;
+  presets: number[];
+  onSelect: (val: number) => void;
+}
+
+const HelpPopover: React.FC<Props> = ({ explanation, presets, onSelect }) => {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <div className="relative inline-block">
+      <button type="button" onClick={() => setOpen(o => !o)} className="ml-1 text-slate-400 hover:text-white">
+        <HelpCircle className="w-4 h-4" />
+      </button>
+      {open && (
+        <div className="absolute z-10 mt-2 w-64 bg-slate-800 text-slate-200 text-sm p-4 rounded-xl border border-slate-700">
+          <p className="mb-2">{explanation}</p>
+          <div className="flex gap-2">
+            {presets.map(p => (
+              <button
+                key={p}
+                onClick={() => { onSelect(p); setOpen(false); }}
+                className="px-2 py-1 bg-slate-700 rounded hover:bg-slate-600"
+              >
+                {p}%
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HelpPopover;

--- a/src/components/K401Form.tsx
+++ b/src/components/K401Form.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DollarSign, Percent, Calendar } from 'lucide-react';
+import HelpPopover from './HelpPopover';
 
 export interface K401FormProps {
   onSubmit: (formData: any) => void;
@@ -123,6 +124,11 @@ const K401Form: React.FC<K401FormProps> = ({ onSubmit, initialData }) => {
             <div className="flex items-center gap-2">
               <Percent className="w-4 h-4 text-teal-400" />
               Annual Return Rate
+              <HelpPopover
+                explanation="The average annual return you expect from this fund. Historically, the S&P 500 has averaged around 10%."
+                presets={[5,7,10]}
+                onSelect={val => handleChange('annualReturnRate', val)}
+              />
             </div>
           </label>
           <input

--- a/src/components/PlanSidebar.tsx
+++ b/src/components/PlanSidebar.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { Plan } from '../types';
+
+interface Props {
+  plans: Plan[];
+  open: boolean;
+  onClose: () => void;
+  onLoad: (plan: Plan) => void;
+  onDelete: (name: string) => void;
+  onCompare: (a: Plan, b: Plan) => void;
+}
+
+const PlanSidebar: React.FC<Props> = ({ plans, open, onClose, onLoad, onDelete, onCompare }) => {
+  const [selected, setSelected] = useState<string[]>([]);
+
+  const toggle = (name: string) => {
+    setSelected(prev => {
+      const exists = prev.includes(name);
+      const next = exists ? prev.filter(n => n !== name) : [...prev, name];
+      return next.slice(-2); // only keep last two selected
+    });
+  };
+
+  const handleCompare = () => {
+    if (selected.length === 2) {
+      const [aName, bName] = selected;
+      const a = plans.find(p => p.name === aName);
+      const b = plans.find(p => p.name === bName);
+      if (a && b) {
+        onCompare(a, b);
+        onClose();
+      }
+    }
+  };
+
+  return (
+    <div className={`fixed top-0 right-0 h-full w-80 bg-slate-900/95 z-40 shadow-xl transform transition-transform ${open ? 'translate-x-0' : 'translate-x-full'}`}>\
+      <div className="p-4 flex justify-between items-center border-b border-slate-700">
+        <h3 className="text-lg font-semibold text-white">My Plans</h3>
+        <button onClick={onClose} className="text-slate-400 hover:text-white">✕</button>
+      </div>
+      <div className="p-4 space-y-4 overflow-y-auto h-[calc(100%-120px)]">
+        {plans.length === 0 && <p className="text-slate-400 text-sm">No saved plans.</p>}
+        {plans.map(plan => (
+          <div key={plan.name} className="flex items-center justify-between bg-slate-800/40 border border-slate-700/50 rounded-lg p-3">
+            <div className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={selected.includes(plan.name)}
+                onChange={() => toggle(plan.name)}
+                className="form-checkbox text-blue-500"
+              />
+              <span className="text-slate-200 text-sm">{plan.name}</span>
+            </div>
+            <div className="flex gap-2">
+              <button onClick={() => onLoad(plan)} className="text-blue-400 text-xs">Load</button>
+              <button onClick={() => onDelete(plan.name)} className="text-red-400 text-xs">Delete</button>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="p-4 border-t border-slate-700">
+        <button
+          disabled={selected.length !== 2}
+          onClick={handleCompare}
+          className="w-full bg-blue-600 disabled:opacity-50 text-white py-2 rounded"
+        >
+          Compare
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default PlanSidebar;

--- a/src/components/RothIRAForm.tsx
+++ b/src/components/RothIRAForm.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DollarSign, Percent, Calendar } from 'lucide-react';
+import HelpPopover from './HelpPopover';
 
 export interface RothIRAFormProps {
   onSubmit: (formData: any) => void;
@@ -69,6 +70,11 @@ const RothIRAForm: React.FC<RothIRAFormProps> = ({ onSubmit, initialData }) => {
             <div className="flex items-center gap-2">
               <Percent className="w-4 h-4 text-blue-400" />
               Annual Growth Rate
+              <HelpPopover
+                explanation="The average annual return you expect from this fund. Historically, the S&P 500 has averaged around 10%."
+                presets={[5,7,10]}
+                onSelect={val => handleChange('annualGrowthRate', val)}
+              />
             </div>
           </label>
           <input

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,10 @@
+export interface Plan {
+  name: string;
+  calculatorType: 'reit' | 'roth' | 'k401' | 'brokerage' | 'hsa';
+  formData: any;
+}
+
+export interface PlanResult {
+  plan: Plan;
+  result: any;
+}


### PR DESCRIPTION
## Summary
- add new sidebar for saving and comparing plans
- add help popover with presets for expected return fields
- allow plan saving with localStorage and load/delete/compare
- overlay comparison chart and summary for two plans

## Testing
- `npx vitest run` *(fails: Cannot find module 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_6843b2f5ede8832091625f126b0f3823