### PR TITLE
Implement contextual plan guidance

### DIFF
--- a/src/components/PlanSidebar.tsx
+++ b/src/components/PlanSidebar.tsx
@@ -46,7 +46,12 @@ const PlanSidebar: React.FC<Props> = ({ plans, open, onClose, onLoad, onDelete, 
         </button>
       </div>
       <div className="p-4 space-y-4 overflow-y-auto h-[calc(100%-120px)]">
-        {plans.length === 0 && <p className="text-slate-400 text-sm">No saved plans.</p>}
+        {plans.length === 0 && (
+          <div className="text-slate-400 text-sm space-y-1 p-2">
+            <div className="font-medium text-slate-300">Your Plans Will Appear Here</div>
+            <p>Run a calculation and save it to get started. You can then create other plans to compare different strategies.</p>
+          </div>
+        )}
         {plans.map(plan => (
           <div key={plan.name} className="flex items-center justify-between bg-slate-800/40 border border-slate-700/50 rounded-lg p-3">
             <div className="flex items-center gap-2">

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+interface Action {
+  label: string;
+  onClick: () => void;
+  primary?: boolean;
+}
+
+interface ToastProps {
+  message: string;
+  actions: Action[];
+  onClose: () => void;
+}
+
+const Toast: React.FC<ToastProps> = ({ message, actions, onClose }) => {
+  return (
+    <div className="fixed bottom-6 left-1/2 transform -translate-x-1/2 bg-slate-800/90 border border-slate-700 rounded-xl px-4 py-3 shadow-xl flex items-center space-x-4">
+      <span className="text-sm text-slate-200">{message}</span>
+      {actions.map(a => (
+        <button
+          key={a.label}
+          onClick={a.onClick}
+          className={`${a.primary ? 'bg-blue-600 hover:bg-blue-700 text-white' : 'bg-slate-700 hover:bg-slate-600 text-slate-200'} text-xs px-3 py-1 rounded`}
+        >
+          {a.label}
+        </button>
+      ))}
+      <button onClick={onClose} className="text-slate-400 hover:text-white text-xs ml-2">✕</button>
+    </div>
+  );
+};
+
+export default Toast;


### PR DESCRIPTION
## Summary
- show a helpful empty state in the My Plans sidebar
- add a generic Toast component
- nudge users to save and compare plans after calculations

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843ba67171883209bfc8ec5fe0d4605