### PR TITLE
Fix plan checkbox and add modern save modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import PlanSidebar from './components/PlanSidebar';
 import { Plan, PlanResult } from './types';
 import ComparisonChart from './components/ComparisonChart';
 import Toast from './components/Toast';
+import PlanNameModal from './components/PlanNameModal';
 import CalculatorForm from './components/CalculatorForm';
 import RothIRAForm from './components/RothIRAForm';
 import K401Form from './components/K401Form';
@@ -81,6 +82,7 @@ function App() {
   const [comparePlans, setComparePlans] = useState<PlanResult[] | null>(null);
   const [showSaveNudge, setShowSaveNudge] = useState(false);
   const [showComparePrompt, setShowComparePrompt] = useState(false);
+  const [showNameModal, setShowNameModal] = useState(false);
   const [lastSavedPlan, setLastSavedPlan] = useState<Plan | null>(null);
   const [lastCalculatedData, setLastCalculatedData] = useState<any>(null);
 
@@ -242,8 +244,10 @@ function App() {
   };
 
   const handleSavePlan = () => {
-    const name = prompt('Plan name');
-    if (!name) return;
+    setShowNameModal(true);
+  };
+
+  const savePlanWithName = (name: string) => {
     const formData =
       calculatorType === 'reit'
         ? reitFormData
@@ -259,6 +263,7 @@ function App() {
     setLastSavedPlan(newPlan);
     setShowSaveNudge(false);
     setShowComparePrompt(false);
+    setShowNameModal(false);
   };
 
   const loadPlan = (plan: Plan) => {
@@ -878,6 +883,11 @@ function App() {
           onClose={() => setShowComparePrompt(false)}
         />
       )}
+      <PlanNameModal
+        open={showNameModal}
+        onSave={savePlanWithName}
+        onClose={() => setShowNameModal(false)}
+      />
     </div>
   );
 }

--- a/src/components/PlanNameModal.tsx
+++ b/src/components/PlanNameModal.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+
+interface Props {
+  open: boolean;
+  onSave: (name: string) => void;
+  onClose: () => void;
+}
+
+const PlanNameModal: React.FC<Props> = ({ open, onSave, onClose }) => {
+  const [name, setName] = useState('');
+
+  const handleSave = () => {
+    const trimmed = name.trim();
+    if (trimmed) {
+      onSave(trimmed);
+      setName('');
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="bg-slate-800 border border-slate-700 rounded-xl p-6 w-80 shadow-xl space-y-4">
+        <h3 className="text-lg font-semibold text-white">Save Plan</h3>
+        <input
+          autoFocus
+          type="text"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          placeholder="Plan name"
+          className="w-full px-3 py-2 rounded bg-slate-700 text-slate-200 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="px-3 py-1 text-sm rounded bg-slate-700 text-slate-200 hover:bg-slate-600"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            className="px-3 py-1 text-sm rounded bg-blue-600 hover:bg-blue-700 text-white"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PlanNameModal;

--- a/src/components/PlanSidebar.tsx
+++ b/src/components/PlanSidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { X } from 'lucide-react';
+import { X, Check } from 'lucide-react';
 import { Plan } from '../types';
 
 interface Props {
@@ -54,15 +54,18 @@ const PlanSidebar: React.FC<Props> = ({ plans, open, onClose, onLoad, onDelete, 
         )}
         {plans.map(plan => (
           <div key={plan.name} className="flex items-center justify-between bg-slate-800/40 border border-slate-700/50 rounded-lg p-3">
-            <div className="flex items-center gap-2">
+            <label className="flex items-center gap-2 relative">
               <input
                 type="checkbox"
                 checked={selected.includes(plan.name)}
                 onChange={() => toggle(plan.name)}
-                className="peer relative appearance-none w-5 h-5 border border-slate-600 rounded-sm bg-slate-800 cursor-pointer checked:bg-gradient-to-br checked:from-blue-500 checked:to-purple-600 checked:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500/50 after:content-['\\2713'] after:absolute after:inset-0 after:flex after:items-center after:justify-center after:text-[10px] after:text-white after:opacity-0 checked:after:opacity-100"
+                className="peer appearance-none w-5 h-5 border border-slate-600 rounded-sm bg-slate-800 cursor-pointer checked:bg-gradient-to-br checked:from-blue-500 checked:to-purple-600 checked:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500/50"
               />
-              <span className="text-slate-200 text-sm">{plan.name}</span>
-            </div>
+              {selected.includes(plan.name) && (
+                <Check className="w-3 h-3 text-white absolute left-1 top-1 pointer-events-none" />
+              )}
+              <span className="text-slate-200 text-sm ml-1">{plan.name}</span>
+            </label>
             <div className="flex gap-2">
               <button
                 onClick={() => onLoad(plan)}


### PR DESCRIPTION
## Summary
- fix checkbox style in PlanSidebar so checkmark renders correctly
- add a polished PlanNameModal component
- swap prompt() for the new modal when saving plans

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843bed149408320bf50d162735bea3d