### PR TITLE
Enable keyboard modal save and outside-click sidebar

### DIFF
--- a/src/components/PlanNameModal.tsx
+++ b/src/components/PlanNameModal.tsx
@@ -17,6 +17,13 @@ const PlanNameModal: React.FC<Props> = ({ open, onSave, onClose }) => {
     }
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSave();
+    }
+  };
+
   if (!open) return null;
 
   return (
@@ -28,6 +35,7 @@ const PlanNameModal: React.FC<Props> = ({ open, onSave, onClose }) => {
           type="text"
           value={name}
           onChange={e => setName(e.target.value)}
+          onKeyDown={handleKeyDown}
           placeholder="Plan name"
           className="w-full px-3 py-2 rounded bg-slate-700 text-slate-200 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
         />

--- a/src/components/PlanSidebar.tsx
+++ b/src/components/PlanSidebar.tsx
@@ -35,10 +35,15 @@ const PlanSidebar: React.FC<Props> = ({ plans, open, onClose, onLoad, onDelete, 
   };
 
   return (
-    <div
-      className={`fixed top-0 right-0 h-full w-80 bg-slate-900/95 z-40 shadow-xl transform transition-transform ${open ? 'translate-x-0' : 'translate-x-full'}`}
-      style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
-    >
+    <>
+      <div
+        onClick={onClose}
+        className={`fixed inset-0 z-30 bg-black/50 transition-opacity duration-300 ${open ? 'opacity-50' : 'opacity-0 pointer-events-none'}`}
+      />
+      <div
+        className={`fixed top-0 right-0 h-full w-80 bg-slate-900/95 z-40 shadow-xl transform transition-transform duration-300 ${open ? 'translate-x-0' : 'translate-x-full'}`}
+        style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+      >
       <div className="p-4 flex justify-between items-center border-b border-slate-700">
         <h3 className="text-lg font-semibold text-white">My Plans</h3>
         <button onClick={onClose} className="text-slate-400 hover:text-white">
@@ -92,7 +97,7 @@ const PlanSidebar: React.FC<Props> = ({ plans, open, onClose, onLoad, onDelete, 
           Compare
         </button>
       </div>
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- save modal submits with Enter key
- close plans sidebar by clicking anywhere outside it and dim background

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843c14a02208320af473aa5b43ffed2