### PR TITLE
Add comparison insights and annual growth chart

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import { Building2, Calculator, ChartBar, TrendingUp, ChevronDown, ChevronUp, In
 import PlanSidebar from './components/PlanSidebar';
 import { Plan, PlanResult } from './types';
 import ComparisonChart from './components/ComparisonChart';
+import AnnualGrowthChart from './components/AnnualGrowthChart';
+import KeyInsights from './components/KeyInsights';
 import Toast from './components/Toast';
 import PlanNameModal from './components/PlanNameModal';
 import CalculatorForm from './components/CalculatorForm';
@@ -750,33 +752,70 @@ function App() {
           {comparePlans && (
             <div className="mb-12">
               <h3 className="text-xl font-semibold mb-4 text-white">Comparison</h3>
-              <ComparisonChart
-                labels={comparePlans[0].result.results.map((r: any) => `Year ${r.year}`)}
-                datasets={[
-                  {
-                    label: comparePlans[0].plan.name,
-                    data: comparePlans[0].result.results.map((r: any) => r.netEquity),
-                    borderColor: 'rgba(99,102,241,1)'
-                  },
-                  {
-                    label: comparePlans[1].plan.name,
-                    data: comparePlans[1].result.results.map((r: any) => r.netEquity),
-                    borderColor: 'rgba(236,72,153,1)'
-                  }
-                ]}
-              />
+              {(() => {
+                const labels = comparePlans[0].result.results.map((r: any) => `Year ${r.year}`);
+                const interestA = comparePlans[0].result.results.map((r: any, idx: number, arr: any[]) =>
+                  idx === 0 ? r.netEquity : r.netEquity - arr[idx - 1].netEquity
+                );
+                const interestB = comparePlans[1].result.results.map((r: any, idx: number, arr: any[]) =>
+                  idx === 0 ? r.netEquity : r.netEquity - arr[idx - 1].netEquity
+                );
+                return (
+                  <>
+                    <div className="grid md:grid-cols-2 gap-8">
+                      <ComparisonChart
+                        labels={labels}
+                        datasets={[
+                          {
+                            label: comparePlans[0].plan.name,
+                            data: comparePlans[0].result.results.map((r: any) => r.netEquity),
+                            borderColor: 'rgba(99,102,241,1)'
+                          },
+                          {
+                            label: comparePlans[1].plan.name,
+                            data: comparePlans[1].result.results.map((r: any) => r.netEquity),
+                            borderColor: 'rgba(236,72,153,1)'
+                          }
+                        ]}
+                      />
+                      <AnnualGrowthChart
+                        labels={labels}
+                        datasets={[
+                          {
+                            label: comparePlans[0].plan.name,
+                            data: interestA,
+                            backgroundColor: 'rgba(99,102,241,0.6)'
+                          },
+                          {
+                            label: comparePlans[1].plan.name,
+                            data: interestB,
+                            backgroundColor: 'rgba(236,72,153,0.6)'
+                          }
+                        ]}
+                      />
+                    </div>
+                    <KeyInsights plans={comparePlans} />
+                  </>
+                );
+              })()}
               <div className="mt-4 grid grid-cols-2 gap-4 text-sm text-slate-200">
-                <div className="bg-slate-800/40 p-4 rounded-xl">
+                <div className="bg-slate-800/40 p-4 rounded-xl space-y-1">
                   <div className="font-semibold mb-2">{comparePlans[0].plan.name}</div>
-                  <div>Final Value: ${comparePlans[0].result.summary.netEquity.toLocaleString()}</div>
-                  <div>Total Contributions: ${comparePlans[0].result.summary.cashExtracted.toLocaleString()}</div>
-                  <div>Total Interest: ${(comparePlans[0].result.summary.netEquity - comparePlans[0].result.summary.cashExtracted).toLocaleString()}</div>
+                  <div className="text-slate-400 text-xs">Final Value</div>
+                  <div className="text-2xl font-bold text-white">${Math.round(comparePlans[0].result.summary.netEquity).toLocaleString()}</div>
+                  <div className="text-slate-400 text-xs">Total Contributions</div>
+                  <div className="font-semibold text-white">${Math.round(comparePlans[0].result.summary.cashExtracted).toLocaleString()}</div>
+                  <div className="text-slate-400 text-xs">Total Interest</div>
+                  <div className="font-semibold text-white">${Math.round(comparePlans[0].result.summary.netEquity - comparePlans[0].result.summary.cashExtracted).toLocaleString()}</div>
                 </div>
-                <div className="bg-slate-800/40 p-4 rounded-xl">
+                <div className="bg-slate-800/40 p-4 rounded-xl space-y-1">
                   <div className="font-semibold mb-2">{comparePlans[1].plan.name}</div>
-                  <div>Final Value: ${comparePlans[1].result.summary.netEquity.toLocaleString()}</div>
-                  <div>Total Contributions: ${comparePlans[1].result.summary.cashExtracted.toLocaleString()}</div>
-                  <div>Total Interest: ${(comparePlans[1].result.summary.netEquity - comparePlans[1].result.summary.cashExtracted).toLocaleString()}</div>
+                  <div className="text-slate-400 text-xs">Final Value</div>
+                  <div className="text-2xl font-bold text-white">${Math.round(comparePlans[1].result.summary.netEquity).toLocaleString()}</div>
+                  <div className="text-slate-400 text-xs">Total Contributions</div>
+                  <div className="font-semibold text-white">${Math.round(comparePlans[1].result.summary.cashExtracted).toLocaleString()}</div>
+                  <div className="text-slate-400 text-xs">Total Interest</div>
+                  <div className="font-semibold text-white">${Math.round(comparePlans[1].result.summary.netEquity - comparePlans[1].result.summary.cashExtracted).toLocaleString()}</div>
                 </div>
               </div>
             </div>

--- a/src/components/AnnualGrowthChart.tsx
+++ b/src/components/AnnualGrowthChart.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+} from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+interface Dataset {
+  label: string;
+  data: number[];
+  backgroundColor: string;
+}
+
+interface Props {
+  labels: string[];
+  datasets: Dataset[];
+}
+
+const AnnualGrowthChart: React.FC<Props> = ({ labels, datasets }) => {
+  return (
+    <div className="h-[300px]">
+      <Bar
+        data={{ labels, datasets }}
+        options={{
+          responsive: true,
+          plugins: {
+            legend: {
+              labels: {
+                color: '#94a3b8',
+                font: { family: "'Inter', sans-serif", size: 12 }
+              }
+            },
+            tooltip: {
+              callbacks: {
+                label: (ctx) => {
+                  const val = ctx.parsed.y;
+                  return `${ctx.dataset.label}: $${val.toLocaleString()}`;
+                }
+              }
+            }
+          },
+          scales: {
+            x: {
+              stacked: false,
+              ticks: { color: '#94a3b8' },
+              grid: { color: 'rgba(148,163,184,0.1)' }
+            },
+            y: {
+              ticks: {
+                color: '#94a3b8',
+                callback: (v: any) => '$' + v.toLocaleString()
+              },
+              grid: { color: 'rgba(148,163,184,0.1)' }
+            }
+          }
+        }}
+      />
+    </div>
+  );
+};
+
+export default AnnualGrowthChart;

--- a/src/components/KeyInsights.tsx
+++ b/src/components/KeyInsights.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { PlanResult } from '../types';
+import { YearlyResult } from './ResultsTable';
+
+interface Props {
+  plans: PlanResult[];
+}
+
+const formatDollar = (v: number) => `$${Math.round(v).toLocaleString()}`;
+
+const firstYearToValue = (results: YearlyResult[], target: number) => {
+  const idx = results.findIndex(r => r.netEquity >= target);
+  return idx >= 0 ? idx + 1 : null;
+};
+
+const KeyInsights: React.FC<Props> = ({ plans }) => {
+  if (plans.length < 2) return null;
+  const [a, b] = plans;
+  const delta = a.result.summary.netEquity - b.result.summary.netEquity;
+  const contribDelta = a.result.summary.cashExtracted - b.result.summary.cashExtracted;
+  const milestone = 250000;
+  const aYear = firstYearToValue(a.result.results, milestone);
+  const bYear = firstYearToValue(b.result.results, milestone);
+  return (
+    <div className="my-6 bg-slate-800/40 p-6 rounded-xl">
+      <h4 className="text-lg font-semibold text-white mb-3">Key Insights</h4>
+      <ul className="list-disc pl-6 space-y-2 text-slate-300 text-sm">
+        <li>
+          <span className="font-semibold text-indigo-400">{a.plan.name}</span> is projected to finish with
+          <span className="font-bold text-indigo-400"> {formatDollar(Math.abs(delta))}</span>
+          {delta >= 0 ? ' more' : ' less'} than
+          <span className="font-semibold text-pink-400"> {b.plan.name}</span>.
+        </li>
+        {contribDelta !== 0 && (
+          <li>
+            This is primarily driven by
+            <span className="font-semibold text-indigo-400"> {delta >= 0 ? a.plan.name : b.plan.name}</span>
+            having
+            <span className="font-bold text-indigo-400"> {formatDollar(Math.abs(contribDelta))}</span>
+            {contribDelta >= 0 ? ' more' : ' less'} in total contributions.
+          </li>
+        )}
+        {aYear && bYear && aYear !== bYear && (
+          <li>
+            <span className="font-semibold text-indigo-400">{aYear < bYear ? a.plan.name : b.plan.name}</span> reaches the
+            <span className="font-bold text-indigo-400"> {formatDollar(milestone)}</span> mark approximately
+            <span className="font-bold text-indigo-400"> {Math.abs(aYear - bYear)}</span> years earlier than
+            <span className="font-semibold text-pink-400"> {aYear < bYear ? b.plan.name : a.plan.name}</span>.
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+};
+
+export default KeyInsights;


### PR DESCRIPTION
## Summary
- add grouped bar chart component for annual interest
- add Key Insights component with automatic takeaways
- enhance comparison section to use the new chart and insights
- restyle summary boxes with clearer emphasis on key figures

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843c4353a1483208facee2ee0f7bfa8