### PR TITLE
Add range summary and goal probability metrics

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,6 +90,7 @@ function App() {
   const [comparePlans, setComparePlans] = useState<PlanResult[] | null>(null);
   const [showSaveNudge, setShowSaveNudge] = useState(false);
   const [showComparePrompt, setShowComparePrompt] = useState(false);
+  const [showMonteCarloNudge, setShowMonteCarloNudge] = useState(false);
   const [showNameModal, setShowNameModal] = useState(false);
   const [lastSavedPlan, setLastSavedPlan] = useState<Plan | null>(null);
   const [lastCalculatedData, setLastCalculatedData] = useState<any>(null);
@@ -172,10 +173,15 @@ function App() {
               : 0,
           equityMultiple: totalInvested > 0 ? finalMedian / totalInvested : 0,
         };
+        const probability =
+          newFormData.target
+            ? (mc.finalValues.filter(v => v >= newFormData.target).length / mc.finalValues.length) * 100
+            : undefined;
         setResults({
           ...summary,
           rangeLow: mc.p10[mc.p10.length - 1],
           rangeHigh: mc.p90[mc.p90.length - 1],
+          goalProbability: probability,
           portfolioMetrics: {
             portfolioComposition: {
               labels: ['Final Balance', 'Total Contributions'],
@@ -216,10 +222,15 @@ function App() {
               : 0,
           equityMultiple: totalInvested > 0 ? finalMedian / totalInvested : 0,
         };
+        const probability =
+          newFormData.target
+            ? (mc.finalValues.filter(v => v >= newFormData.target).length / mc.finalValues.length) * 100
+            : undefined;
         setResults({
           ...summary,
           rangeLow: mc.p10[mc.p10.length - 1],
           rangeHigh: mc.p90[mc.p90.length - 1],
+          goalProbability: probability,
           portfolioMetrics: {
             portfolioComposition: {
               labels: ['Final Balance', 'Total Contributions'],
@@ -260,10 +271,15 @@ function App() {
               : 0,
           equityMultiple: totalInvested > 0 ? finalMedian / totalInvested : 0,
         };
+        const probability =
+          newFormData.target
+            ? (mc.finalValues.filter(v => v >= newFormData.target).length / mc.finalValues.length) * 100
+            : undefined;
         setResults({
           ...summary,
           rangeLow: mc.p10[mc.p10.length - 1],
           rangeHigh: mc.p90[mc.p90.length - 1],
+          goalProbability: probability,
           portfolioMetrics: {
             portfolioComposition: {
               labels: ['Final Balance', 'Total Contributions'],
@@ -304,10 +320,15 @@ function App() {
               : 0,
           equityMultiple: totalInvested > 0 ? finalMedian / totalInvested : 0,
         };
+        const probability =
+          newFormData.target
+            ? (mc.finalValues.filter(v => v >= newFormData.target).length / mc.finalValues.length) * 100
+            : undefined;
         setResults({
           ...summary,
           rangeLow: mc.p10[mc.p10.length - 1],
           rangeHigh: mc.p90[mc.p90.length - 1],
+          goalProbability: probability,
           portfolioMetrics: {
             portfolioComposition: {
               labels: ['Final Balance', 'Total Contributions'],
@@ -339,6 +360,13 @@ function App() {
         JSON.stringify(newFormData) !== JSON.stringify(lastSavedPlan.formData)
       ) {
         setShowComparePrompt(true);
+      }
+      if (
+        calculatorType !== 'reit' &&
+        !sessionStorage.getItem('mcExplainerShown')
+      ) {
+        setShowMonteCarloNudge(true);
+        sessionStorage.setItem('mcExplainerShown', 'true');
       }
     }
   };
@@ -1017,7 +1045,14 @@ function App() {
               }, primary: true },
             { label: 'Save as New Plan', onClick: () => { handleSavePlan(); setShowComparePrompt(false); } }
           ]}
-          onClose={() => setShowComparePrompt(false)}
+        onClose={() => setShowComparePrompt(false)}
+      />
+      )}
+      {showMonteCarloNudge && (
+        <Toast
+          message="A More Realistic Projection - Instead of one guess, we simulated 1,000+ potential market scenarios to show a likely range of outcomes for your plan."
+          actions={[{ label: 'Got it', onClick: () => setShowMonteCarloNudge(false), primary: true }]}
+          onClose={() => setShowMonteCarloNudge(false)}
         />
       )}
       <PlanNameModal

--- a/src/components/BrokerageForm.tsx
+++ b/src/components/BrokerageForm.tsx
@@ -16,6 +16,7 @@ const BrokerageForm: React.FC<BrokerageFormProps> = ({ onSubmit, initialData }) 
     taxRate: initialData?.taxRate ?? 15,
     years: initialData?.years ?? 30,
     riskProfile: initialData?.riskProfile ?? 'medium',
+    target: initialData?.target ?? ''
   });
 
   const handleChange = (field: string, value: string | number) => {
@@ -154,6 +155,22 @@ const BrokerageForm: React.FC<BrokerageFormProps> = ({ onSubmit, initialData }) 
             <option value="medium">Medium</option>
             <option value="high">High</option>
           </select>
+        </div>
+        <div>
+          <label className={labelClasses}>
+            <div className="flex items-center gap-2">
+              <DollarSign className="w-4 h-4 text-green-400" />
+              What is your financial target?
+            </div>
+          </label>
+          <input
+            type="number"
+            value={formData.target}
+            onChange={e => handleChange('target', e.target.value)}
+            className={inputClasses}
+            step="1000"
+            min="0"
+          />
         </div>
       </div>
       <button

--- a/src/components/GoalProbabilityCard.tsx
+++ b/src/components/GoalProbabilityCard.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Percent } from 'lucide-react';
+
+interface Props {
+  probability: number;
+}
+
+const GoalProbabilityCard: React.FC<Props> = ({ probability }) => {
+  const pct = Math.max(0, Math.min(100, probability));
+  return (
+    <div className="group relative bg-slate-800/40 backdrop-blur-sm border border-slate-700/50 rounded-2xl p-6 hover:bg-slate-800/60 transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl hover:shadow-blue-500/10">
+      <div className="flex items-center gap-3 mb-4">
+        <div className="w-10 h-10 bg-gradient-to-br from-green-500 to-emerald-600 rounded-xl flex items-center justify-center shadow-lg">
+          <Percent className="w-5 h-5 text-white" />
+        </div>
+        <div>
+          <h3 className="text-sm font-medium text-slate-400">Probability of Reaching Target</h3>
+          <p className="text-xs text-slate-500">Chance of hitting goal</p>
+        </div>
+      </div>
+      <div className="text-3xl font-bold text-white mb-2">{pct.toFixed(0)}%</div>
+      <div className="w-full h-2 bg-slate-700 rounded-full overflow-hidden mb-1">
+        <div className="h-full bg-gradient-to-r from-green-400 to-blue-500" style={{ width: `${pct}%` }} />
+      </div>
+      <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 to-purple-500/10 rounded-xl opacity-0 group-hover:opacity-100 transition-opacity duration-500 blur-xl" />
+    </div>
+  );
+};
+
+export default GoalProbabilityCard;

--- a/src/components/HSAForm.tsx
+++ b/src/components/HSAForm.tsx
@@ -15,6 +15,7 @@ const HSAForm: React.FC<HSAFormProps> = ({ onSubmit, initialData }) => {
     annualGrowthRate: initialData?.annualGrowthRate ?? 7,
     years: initialData?.years ?? 30,
     riskProfile: initialData?.riskProfile ?? 'medium',
+    target: initialData?.target ?? ''
   });
 
   const handleChange = (field: string, value: string | number) => {
@@ -136,6 +137,22 @@ const HSAForm: React.FC<HSAFormProps> = ({ onSubmit, initialData }) => {
             <option value="medium">Medium</option>
             <option value="high">High</option>
           </select>
+        </div>
+        <div>
+          <label className={labelClasses}>
+            <div className="flex items-center gap-2">
+              <DollarSign className="w-4 h-4 text-green-400" />
+              What is your financial target?
+            </div>
+          </label>
+          <input
+            type="number"
+            value={formData.target}
+            onChange={e => handleChange('target', e.target.value)}
+            className={inputClasses}
+            step="1000"
+            min="0"
+          />
         </div>
       </div>
       <button

--- a/src/components/K401Form.tsx
+++ b/src/components/K401Form.tsx
@@ -18,6 +18,7 @@ const K401Form: React.FC<K401FormProps> = ({ onSubmit, initialData }) => {
     taxRate: initialData?.taxRate ?? 20,
     years: initialData?.years ?? 30,
     riskProfile: initialData?.riskProfile ?? 'medium',
+    target: initialData?.target ?? ''
   });
 
   const handleChange = (field: string, value: string | number) => {
@@ -190,6 +191,22 @@ const K401Form: React.FC<K401FormProps> = ({ onSubmit, initialData }) => {
             <option value="medium">Medium</option>
             <option value="high">High</option>
           </select>
+        </div>
+        <div>
+          <label className={labelClasses}>
+            <div className="flex items-center gap-2">
+              <DollarSign className="w-4 h-4 text-green-400" />
+              What is your financial target?
+            </div>
+          </label>
+          <input
+            type="number"
+            value={formData.target}
+            onChange={e => handleChange('target', e.target.value)}
+            className={inputClasses}
+            step="1000"
+            min="0"
+          />
         </div>
       </div>
       <button

--- a/src/components/RangeSummary.tsx
+++ b/src/components/RangeSummary.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+interface RangeSummaryProps {
+  pessimistic: number;
+  likely: number;
+  optimistic: number;
+}
+
+const formatCurrency = (val: number) =>
+  `$${Math.round(val).toLocaleString()}`;
+
+const RangeSummary: React.FC<RangeSummaryProps> = ({ pessimistic, likely, optimistic }) => {
+  return (
+    <div className="bg-slate-800/40 backdrop-blur-sm border border-slate-700/50 rounded-2xl p-6 flex justify-between text-center">
+      <div className="flex-1">
+        <div className="text-sm text-slate-400 mb-1">Pessimistic</div>
+        <div className="text-lg font-semibold text-red-300">{formatCurrency(pessimistic)}</div>
+      </div>
+      <div className="flex-1">
+        <div className="text-sm text-slate-400 mb-1">Likely Projection</div>
+        <div className="text-2xl font-bold text-white">{formatCurrency(likely)}</div>
+      </div>
+      <div className="flex-1">
+        <div className="text-sm text-slate-400 mb-1">Optimistic</div>
+        <div className="text-lg font-semibold text-green-300">{formatCurrency(optimistic)}</div>
+      </div>
+    </div>
+  );
+};
+
+export default RangeSummary;

--- a/src/components/RothIRAForm.tsx
+++ b/src/components/RothIRAForm.tsx
@@ -14,6 +14,7 @@ const RothIRAForm: React.FC<RothIRAFormProps> = ({ onSubmit, initialData }) => {
     annualGrowthRate: initialData?.annualGrowthRate ?? 7,
     years: initialData?.years ?? 30,
     riskProfile: initialData?.riskProfile ?? 'medium',
+    target: initialData?.target ?? ''
   });
 
   const handleChange = (field: string, value: string | number) => {
@@ -119,6 +120,22 @@ const RothIRAForm: React.FC<RothIRAFormProps> = ({ onSubmit, initialData }) => {
             <option value="medium">Medium</option>
             <option value="high">High</option>
           </select>
+        </div>
+        <div>
+          <label className={labelClasses}>
+            <div className="flex items-center gap-2">
+              <DollarSign className="w-4 h-4 text-green-400" />
+              What is your financial target?
+            </div>
+          </label>
+          <input
+            type="number"
+            value={formData.target}
+            onChange={e => handleChange('target', e.target.value)}
+            className={inputClasses}
+            step="1000"
+            min="0"
+          />
         </div>
       </div>
       <button

--- a/src/components/SummaryCards.tsx
+++ b/src/components/SummaryCards.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Building2, DollarSign, TrendingUp, Wallet, ArrowUpRight, Percent, Activity } from 'lucide-react';
+import RangeSummary from './RangeSummary';
+import GoalProbabilityCard from './GoalProbabilityCard';
 
 export interface SummaryCardsProps {
   results: {
@@ -13,12 +15,14 @@ export interface SummaryCardsProps {
     years: number;
     rangeLow?: number;
     rangeHigh?: number;
+    goalProbability?: number;
   };
   calculatorType: 'reit' | 'roth' | 'k401' | 'brokerage' | 'hsa';
 }
 
 const SummaryCards: React.FC<SummaryCardsProps> = ({ results, calculatorType }) => {
   const isREIT = calculatorType === 'reit';
+  const showMonteCarloRange = !isREIT && results.rangeLow !== undefined;
   const cardData = isREIT ? [
     {
       title: 'Total Properties',
@@ -121,7 +125,16 @@ const SummaryCards: React.FC<SummaryCardsProps> = ({ results, calculatorType }) 
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-      {cardData.map((card, index) => (
+      {showMonteCarloRange && (
+        <RangeSummary
+          pessimistic={results.rangeLow!}
+          likely={results.portfolioValue}
+          optimistic={results.rangeHigh!}
+        />
+      )}
+      {cardData
+        .filter((_, idx) => !(showMonteCarloRange && idx === 0))
+        .map((card, index) => (
         <div
           key={index}
           className="group relative bg-slate-800/40 backdrop-blur-sm border border-slate-700/50 rounded-2xl p-6 hover:bg-slate-800/60 transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl hover:shadow-blue-500/10"
@@ -172,6 +185,9 @@ const SummaryCards: React.FC<SummaryCardsProps> = ({ results, calculatorType }) 
           <div className="absolute inset-0 bg-gradient-to-br from-blue-500/5 to-purple-500/5 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
         </div>
       ))}
+      {showMonteCarloRange && results.goalProbability !== undefined && (
+        <GoalProbabilityCard probability={results.goalProbability} />
+      )}
     </div>
   );
 };

--- a/src/utils/monteCarlo.ts
+++ b/src/utils/monteCarlo.ts
@@ -19,6 +19,7 @@ export interface MonteCarloResult {
   p10: number[];
   p50: number[];
   p90: number[];
+  finalValues: number[];
 }
 
 export function runMonteCarlo(
@@ -43,16 +44,21 @@ export function runMonteCarlo(
   const p10: number[] = [];
   const p50: number[] = [];
   const p90: number[] = [];
+  const finalValues: number[] = [];
   for (let y = 0; y < years; y++) {
     const vals = trials.map(t => t[y]).sort((a, b) => a - b);
     p10.push(quantileSorted(vals, 0.1));
     p50.push(quantileSorted(vals, 0.5));
     p90.push(quantileSorted(vals, 0.9));
   }
+  for (const t of trials) {
+    finalValues.push(t[t.length - 1]);
+  }
   return {
     labels: Array.from({ length: years }, (_, i) => `Year ${i + 1}`),
     p10,
     p50,
     p90,
+    finalValues,
   };
 }


### PR DESCRIPTION
## Summary
- provide Monte Carlo outcome range in new `RangeSummary` component
- show probability of reaching a financial target with `GoalProbabilityCard`
- support optional target input on account forms
- surface a one-time Monte Carlo explainer notification
- expose final trial values from `runMonteCarlo`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843c58f56fc8320b19e577b5bc64e34