### PR TITLE
Refactor metrics dashboard

### DIFF
--- a/src/components/GoalProbabilityCard.tsx
+++ b/src/components/GoalProbabilityCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Percent } from 'lucide-react';
+import MetricCard from './MetricCard';
 
 interface Props {
   probability: number;
@@ -8,22 +9,17 @@ interface Props {
 const GoalProbabilityCard: React.FC<Props> = ({ probability }) => {
   const pct = Math.max(0, Math.min(100, probability));
   return (
-    <div className="group relative bg-slate-800/40 backdrop-blur-sm border border-slate-700/50 rounded-2xl p-6 hover:bg-slate-800/60 transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl hover:shadow-blue-500/10">
-      <div className="flex items-center gap-3 mb-4">
-        <div className="w-10 h-10 bg-gradient-to-br from-green-500 to-emerald-600 rounded-xl flex items-center justify-center shadow-lg">
-          <Percent className="w-5 h-5 text-white" />
-        </div>
-        <div>
-          <h3 className="text-sm font-medium text-slate-400">Probability of Reaching Target</h3>
-          <p className="text-xs text-slate-500">Chance of hitting goal</p>
-        </div>
-      </div>
-      <div className="text-3xl font-bold text-white mb-2">{pct.toFixed(0)}%</div>
-      <div className="w-full h-2 bg-slate-700 rounded-full overflow-hidden mb-1">
+    <MetricCard
+      icon={Percent}
+      title="Goal Probability"
+      value={`${pct.toFixed(0)}%`}
+      subtitle="Chance of reaching target"
+      gradient="from-green-500 to-emerald-600"
+    >
+      <div className="w-full h-2 bg-slate-700 rounded-full overflow-hidden my-1">
         <div className="h-full bg-gradient-to-r from-green-400 to-blue-500" style={{ width: `${pct}%` }} />
       </div>
-      <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 to-purple-500/10 rounded-xl opacity-0 group-hover:opacity-100 transition-opacity duration-500 blur-xl" />
-    </div>
+    </MetricCard>
   );
 };
 

--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+interface MetricCardProps {
+  icon: React.ElementType;
+  title: string;
+  value: React.ReactNode;
+  subtitle: string;
+  gradient: string;
+  children?: React.ReactNode;
+}
+
+const MetricCard: React.FC<MetricCardProps> = ({ icon: Icon, title, value, subtitle, gradient, children }) => {
+  return (
+    <div className="bg-slate-800/40 backdrop-blur-sm border border-slate-700/50 rounded-2xl p-6">
+      <div className="flex items-center gap-3 mb-2">
+        <div className={`w-10 h-10 bg-gradient-to-br ${gradient} rounded-xl flex items-center justify-center shadow-lg`}>
+          <Icon className="w-5 h-5 text-white" />
+        </div>
+        <h3 className="text-sm font-medium text-slate-400">{title}</h3>
+      </div>
+      <div className="text-3xl font-bold text-white">{value}</div>
+      {children}
+      <div className="text-xs text-slate-500 mt-1">{subtitle}</div>
+    </div>
+  );
+};
+
+export default MetricCard;

--- a/src/components/RangeSummary.tsx
+++ b/src/components/RangeSummary.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Target } from 'lucide-react';
+import MetricCard from './MetricCard';
 
 interface RangeSummaryProps {
   pessimistic: number;
@@ -6,25 +8,24 @@ interface RangeSummaryProps {
   optimistic: number;
 }
 
-const formatCurrency = (val: number) =>
-  `$${Math.round(val).toLocaleString()}`;
+const abbreviate = (num: number) => {
+  if (num >= 1_000_000)
+    return `$${(num / 1_000_000).toFixed(1)}M`;
+  if (num >= 1_000)
+    return `$${Math.round(num / 1000)}K`;
+  return `$${Math.round(num)}`;
+};
 
 const RangeSummary: React.FC<RangeSummaryProps> = ({ pessimistic, likely, optimistic }) => {
+  const subtitle = `Range: ${abbreviate(pessimistic)} - ${abbreviate(optimistic)}`;
   return (
-    <div className="bg-slate-800/40 backdrop-blur-sm border border-slate-700/50 rounded-2xl p-6 flex justify-between text-center">
-      <div className="flex-1">
-        <div className="text-sm text-slate-400 mb-1">Pessimistic</div>
-        <div className="text-lg font-semibold text-red-300">{formatCurrency(pessimistic)}</div>
-      </div>
-      <div className="flex-1">
-        <div className="text-sm text-slate-400 mb-1">Likely Projection</div>
-        <div className="text-2xl font-bold text-white">{formatCurrency(likely)}</div>
-      </div>
-      <div className="flex-1">
-        <div className="text-sm text-slate-400 mb-1">Optimistic</div>
-        <div className="text-lg font-semibold text-green-300">{formatCurrency(optimistic)}</div>
-      </div>
-    </div>
+    <MetricCard
+      icon={Target}
+      title="Likely Projection"
+      value={abbreviate(likely)}
+      subtitle={subtitle}
+      gradient="from-blue-500 to-purple-600"
+    />
   );
 };
 

--- a/src/components/SummaryCards.tsx
+++ b/src/components/SummaryCards.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Building2, DollarSign, TrendingUp, Wallet, ArrowUpRight, Percent, Activity } from 'lucide-react';
+import { Building2, DollarSign, TrendingUp, Wallet, Percent, Activity, ArrowUpRight } from 'lucide-react';
 import RangeSummary from './RangeSummary';
 import GoalProbabilityCard from './GoalProbabilityCard';
+import MetricCard from './MetricCard';
 
 export interface SummaryCardsProps {
   results: {
@@ -20,171 +21,135 @@ export interface SummaryCardsProps {
   calculatorType: 'reit' | 'roth' | 'k401' | 'brokerage' | 'hsa';
 }
 
+const formatCurrency = (val: number) => {
+  if (val >= 1_000_000) return `$${(val / 1_000_000).toFixed(1)}M`;
+  if (val >= 1_000) return `$${Math.round(val / 1000)}K`;
+  return `$${Math.round(val)}`;
+};
+
 const SummaryCards: React.FC<SummaryCardsProps> = ({ results, calculatorType }) => {
   const isREIT = calculatorType === 'reit';
   const showMonteCarloRange = !isREIT && results.rangeLow !== undefined;
-  const cardData = isREIT ? [
-    {
-      title: 'Total Properties',
-      value: results.propertyCount,
-      format: (val: number) => val.toString(),
-      icon: Building2,
-      gradient: 'from-blue-500 to-purple-600',
-      description: 'Active portfolio properties'
-    },
-    {
-      title: 'Portfolio Value',
-      value: results.portfolioValue,
-      format: (val: number) => `$${(val / 1000000).toFixed(1)}M`,
-      icon: DollarSign,
-      gradient: 'from-green-500 to-emerald-600',
-      description: 'Total property value'
-    },
-    {
-      title: 'Net Equity',
-      value: results.netEquity,
-      format: (val: number) => `$${(val / 1000000).toFixed(1)}M`,
-      icon: TrendingUp,
-      gradient: 'from-purple-500 to-pink-600',
-      description: 'Total equity position'
-    },
-    {
-      title: 'Total ROI',
-      value: results.roi,
-      format: (val: number) => `${val.toFixed(0)}%`,
-      icon: Percent,
-      gradient: 'from-yellow-500 to-orange-600',
-      description: 'Return on investment'
-    },
-    {
-      title: 'Cash Extracted',
-      value: results.cashExtracted,
-      format: (val: number) => `$${(val / 1000000).toFixed(1)}M`,
-      icon: Wallet,
-      gradient: 'from-cyan-500 to-blue-600',
-      description: 'Total cash pulled out'
-    },
-    {
-      title: 'Annualized Return',
-      value: results.annualizedReturn,
-      format: (val: number) => `${val.toFixed(1)}%`,
-      icon: ArrowUpRight,
-      gradient: 'from-indigo-500 to-violet-600',
-      description: 'Yearly return rate'
-    },
-    {
-      title: 'Equity Multiple',
-      value: results.equityMultiple,
-      format: (val: number) => typeof val === 'number' && !isNaN(val) ? `${val.toFixed(2)}x` : 'N/A',
-      icon: Activity,
-      gradient: 'from-rose-500 to-pink-600',
-      description: 'Equity growth multiple'
-    }
-  ] : [
-    {
-      title: 'Account Balance',
-      value: results.portfolioValue,
-      format: (val: number) => `$${(val / 1000000).toFixed(1)}M`,
-      icon: DollarSign,
-      gradient: 'from-green-500 to-emerald-600',
-      description: 'Projected value'
-    },
-    {
-      title: 'Total Contributions',
-      value: results.cashExtracted,
-      format: (val: number) => `$${(val / 1000000).toFixed(1)}M`,
-      icon: Wallet,
-      gradient: 'from-cyan-500 to-blue-600',
-      description: 'Invested capital'
-    },
-    {
-      title: 'Total ROI',
-      value: results.roi,
-      format: (val: number) => `${val.toFixed(0)}%`,
-      icon: Percent,
-      gradient: 'from-yellow-500 to-orange-600',
-      description: 'Return on investment'
-    },
-    {
-      title: 'Annualized Return',
-      value: results.annualizedReturn,
-      format: (val: number) => `${val.toFixed(1)}%`,
-      icon: ArrowUpRight,
-      gradient: 'from-indigo-500 to-violet-600',
-      description: 'Yearly return rate'
-    },
-    {
-      title: 'Equity Multiple',
-      value: results.equityMultiple,
-      format: (val: number) => typeof val === 'number' && !isNaN(val) ? `${val.toFixed(2)}x` : 'N/A',
-      icon: Activity,
-      gradient: 'from-rose-500 to-pink-600',
-      description: 'Growth multiple'
-    }
-  ];
+
+  const cardData = isREIT
+    ? [
+        {
+          title: 'Total Properties',
+          value: results.propertyCount,
+          format: (val: number) => val.toString(),
+          icon: Building2,
+          gradient: 'from-blue-500 to-purple-600',
+          subtitle: 'Active portfolio properties',
+        },
+        {
+          title: 'Portfolio Value',
+          value: results.portfolioValue,
+          format: formatCurrency,
+          icon: DollarSign,
+          gradient: 'from-green-500 to-emerald-600',
+          subtitle: 'Total property value',
+        },
+        {
+          title: 'Net Equity',
+          value: results.netEquity,
+          format: formatCurrency,
+          icon: TrendingUp,
+          gradient: 'from-purple-500 to-pink-600',
+          subtitle: 'Total equity position',
+        },
+        {
+          title: 'Total ROI',
+          value: results.roi,
+          format: (val: number) => `${val.toFixed(0)}%`,
+          icon: Percent,
+          gradient: 'from-yellow-500 to-orange-600',
+          subtitle: 'Return on investment',
+        },
+        {
+          title: 'Cash Extracted',
+          value: results.cashExtracted,
+          format: formatCurrency,
+          icon: Wallet,
+          gradient: 'from-cyan-500 to-blue-600',
+          subtitle: 'Total cash pulled out',
+        },
+        {
+          title: 'Annualized Return',
+          value: results.annualizedReturn,
+          format: (val: number) => `${val.toFixed(1)}%`,
+          icon: ArrowUpRight,
+          gradient: 'from-indigo-500 to-violet-600',
+          subtitle: 'Average yearly return rate',
+        },
+        {
+          title: 'Equity Multiple',
+          value: results.equityMultiple,
+          format: (val: number) => (typeof val === 'number' && !isNaN(val) ? `${val.toFixed(2)}x` : 'N/A'),
+          icon: Activity,
+          gradient: 'from-rose-500 to-pink-600',
+          subtitle: 'Equity growth multiple',
+        },
+      ]
+    : [
+        {
+          title: 'Account Balance',
+          value: results.portfolioValue,
+          format: formatCurrency,
+          icon: DollarSign,
+          gradient: 'from-green-500 to-emerald-600',
+          subtitle: 'Likely portfolio value',
+        },
+        {
+          title: 'Total Contributions',
+          value: results.cashExtracted,
+          format: formatCurrency,
+          icon: Wallet,
+          gradient: 'from-cyan-500 to-blue-600',
+          subtitle: 'Total capital invested',
+        },
+        {
+          title: 'Total ROI',
+          value: results.roi,
+          format: (val: number) => `${val.toFixed(0)}%`,
+          icon: Percent,
+          gradient: 'from-yellow-500 to-orange-600',
+          subtitle: 'Return on investment',
+        },
+        {
+          title: 'Annualized Return',
+          value: results.annualizedReturn,
+          format: (val: number) => `${val.toFixed(1)}%`,
+          icon: ArrowUpRight,
+          gradient: 'from-indigo-500 to-violet-600',
+          subtitle: 'Average yearly return rate',
+        },
+        {
+          title: 'Equity Multiple',
+          value: results.equityMultiple,
+          format: (val: number) => (typeof val === 'number' && !isNaN(val) ? `${val.toFixed(2)}x` : 'N/A'),
+          icon: Activity,
+          gradient: 'from-rose-500 to-pink-600',
+          subtitle: 'Initial investment growth',
+        },
+      ];
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
       {showMonteCarloRange && (
-        <RangeSummary
-          pessimistic={results.rangeLow!}
-          likely={results.portfolioValue}
-          optimistic={results.rangeHigh!}
-        />
+        <RangeSummary pessimistic={results.rangeLow!} likely={results.portfolioValue} optimistic={results.rangeHigh!} />
       )}
       {cardData
         .filter((_, idx) => !(showMonteCarloRange && idx === 0))
         .map((card, index) => (
-        <div
-          key={index}
-          className="group relative bg-slate-800/40 backdrop-blur-sm border border-slate-700/50 rounded-2xl p-6 hover:bg-slate-800/60 transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl hover:shadow-blue-500/10"
-          style={{
-            animationDelay: `${index * 100}ms`
-          }}
-        >
-          {/* Card Header */}
-          <div className="flex items-start justify-between mb-4">
-            <div className="flex items-center gap-3">
-              <div className={`w-10 h-10 bg-gradient-to-br ${card.gradient} rounded-xl flex items-center justify-center shadow-lg`}>
-                <card.icon className="w-5 h-5 text-white" />
-              </div>
-              <div>
-                <h3 className="text-sm font-medium text-slate-400">{card.title}</h3>
-                <p className="text-xs text-slate-500">{card.description}</p>
-              </div>
-            </div>
-            <div className="w-8 h-8 bg-slate-700/50 rounded-lg flex items-center justify-center group-hover:bg-slate-700/70 transition-colors">
-              <ArrowUpRight className="w-4 h-4 text-slate-400 group-hover:text-white transition-colors" />
-            </div>
-          </div>
-
-          {/* Card Value */}
-          <div className="relative">
-            <div className="text-3xl font-bold text-white mb-1">
-              {card.format(card.value)}
-            </div>
-            {index === 0 && results.rangeLow !== undefined && (
-              <div className="text-xs text-slate-400">
-                Range: {`$${(results.rangeLow / 1000000).toFixed(1)}M`} - {`$${(results.rangeHigh / 1000000).toFixed(1)}M`}
-              </div>
-            )}
-            
-            {/* Animated background gradient */}
-            <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 to-purple-500/10 rounded-xl opacity-0 group-hover:opacity-100 transition-opacity duration-500 blur-xl" />
-          </div>
-
-          {/* Card Footer */}
-          <div className="mt-4 pt-4 border-t border-slate-700/30">
-            <div className="flex items-center justify-between text-sm">
-              <span className="text-slate-400">{results.years}-Year Projection</span>
-              <span className="text-slate-300 font-medium">Compound Growth</span>
-            </div>
-          </div>
-
-          {/* Hover effect overlay */}
-          <div className="absolute inset-0 bg-gradient-to-br from-blue-500/5 to-purple-500/5 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
-        </div>
-      ))}
+          <MetricCard
+            key={index}
+            icon={card.icon}
+            title={card.title}
+            value={card.format(card.value)}
+            subtitle={card.subtitle}
+            gradient={card.gradient}
+          />
+        ))}
       {showMonteCarloRange && results.goalProbability !== undefined && (
         <GoalProbabilityCard probability={results.goalProbability} />
       )}
@@ -192,4 +157,4 @@ const SummaryCards: React.FC<SummaryCardsProps> = ({ results, calculatorType }) 
   );
 };
 
-export default SummaryCards; 
+export default SummaryCards;


### PR DESCRIPTION
## Summary
- create reusable `MetricCard` component
- restyle `RangeSummary` and `GoalProbabilityCard` to use `MetricCard`
- rebuild metric list in `SummaryCards` using the new template and abbreviated currency formatting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843c7f6bb088320b89b39b5f7d079dd