### PR TITLE
Enhance tax rate inputs with slider control

### DIFF
--- a/src/components/BrokerageForm.tsx
+++ b/src/components/BrokerageForm.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { DollarSign, Percent, Calendar } from 'lucide-react';
 import HelpPopover from './HelpPopover';
+import SliderNumberInput from './SliderNumberInput';
 
 export interface BrokerageFormProps {
   onSubmit: (formData: any) => void;
@@ -113,14 +114,13 @@ const BrokerageForm: React.FC<BrokerageFormProps> = ({ onSubmit, initialData }) 
               Tax Rate %
             </div>
           </label>
-          <input
-            type="number"
+          <SliderNumberInput
             value={formData.taxRate}
-            onChange={e => handleChange('taxRate', e.target.value)}
-            className={inputClasses}
-            step="0.1"
-            min="0"
-            max="100"
+            onChange={val => handleChange('taxRate', val)}
+            min={0}
+            max={100}
+            step={0.1}
+            numberInputClassName={inputClasses}
           />
         </div>
         <div>

--- a/src/components/K401Form.tsx
+++ b/src/components/K401Form.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { DollarSign, Percent, Calendar } from 'lucide-react';
 import HelpPopover from './HelpPopover';
+import SliderNumberInput from './SliderNumberInput';
 
 export interface K401FormProps {
   onSubmit: (formData: any) => void;
@@ -149,14 +150,13 @@ const K401Form: React.FC<K401FormProps> = ({ onSubmit, initialData }) => {
               Tax Rate %
             </div>
           </label>
-          <input
-            type="number"
+          <SliderNumberInput
             value={formData.taxRate}
-            onChange={e => handleChange('taxRate', e.target.value)}
-            className={inputClasses}
-            step="0.1"
-            min="0"
-            max="100"
+            onChange={val => handleChange('taxRate', val)}
+            min={0}
+            max={100}
+            step={0.1}
+            numberInputClassName={inputClasses}
           />
         </div>
         <div>

--- a/src/components/SliderNumberInput.tsx
+++ b/src/components/SliderNumberInput.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+interface Props {
+  value: number;
+  onChange: (val: number) => void;
+  min: number;
+  max: number;
+  step?: number;
+  numberInputClassName?: string;
+  className?: string;
+}
+
+const SliderNumberInput: React.FC<Props> = ({
+  value,
+  onChange,
+  min,
+  max,
+  step = 1,
+  numberInputClassName = '',
+  className = ''
+}) => {
+  const progress = ((value - min) / (max - min)) * 100;
+  const sliderStyle = {
+    background: `linear-gradient(to right, #7c3aed 0%, #7c3aed ${progress}%, #4c1d95 ${progress}%, #4c1d95 100%)`
+  } as React.CSSProperties;
+
+  const handleRangeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(Number(e.target.value));
+  };
+
+  const handleNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value === '' ? 0 : Number(e.target.value);
+    onChange(val);
+  };
+
+  return (
+    <div className={`flex items-center gap-4 ${className}`}>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={handleRangeChange}
+        className="range-slider flex-1"
+        style={sliderStyle}
+      />
+      <input
+        type="number"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={handleNumberChange}
+        className={`w-20 ${numberInputClassName}`}
+      />
+    </div>
+  );
+};
+
+export default SliderNumberInput;

--- a/src/index.css
+++ b/src/index.css
@@ -423,3 +423,36 @@ body.dark-mode {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 } 
+/* Slider styles */
+.range-slider {
+  -webkit-appearance: none;
+  width: 100%;
+  height: 6px;
+  border-radius: 9999px;
+  background: #4c1d95;
+  outline: none;
+  cursor: pointer;
+}
+.range-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 2px solid #a855f7;
+  transition: box-shadow 0.2s;
+}
+.range-slider::-webkit-slider-thumb:hover {
+  box-shadow: 0 0 0 4px rgba(168,85,247,0.3);
+}
+.range-slider::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 2px solid #a855f7;
+}
+.range-slider::-moz-range-track {
+  background: transparent;
+}


### PR DESCRIPTION
## Summary
- introduce `SliderNumberInput` for a combined slider/number field
- style the slider widget
- replace plain number inputs for tax rate in 401k and brokerage forms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843ca3dde508320930d0ec549acf656